### PR TITLE
Added support for private repositories

### DIFF
--- a/app/src/main/scala/giter8.scala
+++ b/app/src/main/scala/giter8.scala
@@ -39,7 +39,7 @@ class Giter8 extends xsbti.AppMain with Discover with Apply {
 
   def wrap_creds(r: Request) = {
     check_creds match {
-      case Some((u,p)) => r as_! (u,p)
+      case Some((u,p)) => (r as_! (u,p)).secure
       case None => r
     }
   }


### PR DESCRIPTION
This is a minor modification of work begun by KirinDave that adds support for private repositories via a `~/.giter8-credentials` file. 
