### PR TITLE
Fix SBT doc link in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,8 +8,8 @@ templates published on github. It's implemented in Scala and runs
 through the [Simple Build Tool launcher][launcher], but it
 can produce output for any purpose.
 
-[launcher]: http://code.google.com/p/simple-build-tool/wiki/GeneralizedLauncher
- 
+[launcher]: https://github.com/harrah/xsbt/wiki/
+
 Installation
 ------------
 


### PR DESCRIPTION
Hi,

Since SBT and its documentation have moved to github, please fix the link to SBT doc in `README.markdown`
