### PR TITLE
Add some formatting options for attributes

### DIFF
--- a/app/src/main/scala/apply.scala
+++ b/app/src/main/scala/apply.scala
@@ -90,6 +90,7 @@ trait Apply extends Defaults { self: Giter8 =>
             templates: Iterable[FileInfo],
             parameters: Map[String,String],
             base: File) = {
+    val renderer = new StringRenderer
     templates.foreach { case FileInfo(name, hash, mime, mode) =>
       import org.clapper.scalasti.StringTemplate
       import java.nio.charset.MalformedInputException
@@ -100,7 +101,7 @@ trait Apply extends Defaults { self: Giter8 =>
           }))
         case x => x
       }: _*)
-      val f = new File(base, new StringTemplate(name).setAttributes(fileParams).toString)
+      val f = new File(base, new StringTemplate(formatize(name)).setAttributes(fileParams).registerRenderer(renderer).toString)
       if (f.exists)
         println("Skipping existing file: %s" format f.toString)
       else {
@@ -111,7 +112,7 @@ trait Apply extends Defaults { self: Giter8 =>
             try {
               http(show(repo, hash) >- { in =>
                 use (new FileWriter(f)) { fw =>
-                  fw.write(new StringTemplate(in).setAttributes(parameters).toString)
+                  fw.write(new StringTemplate(in).setAttributes(parameters).registerRenderer(renderer).toString)
                   Some(())
                 }
               })
@@ -158,7 +159,41 @@ trait Apply extends Defaults { self: Giter8 =>
     }
   }
   def normalize(s: String) = s.toLowerCase.replaceAll("""\s+""", "-")
+  def formatize(s: String) = s.replaceAll("""\$(\w+)__(\w+)\$""", """\$$1;format="$2"\$""")
   def show(repo: String, hash: String) = gh / "blob" / "show" / repo / hash
   private def use[C <: { def close(): Unit }, T](c: C)(f: C => T): T =
     try { f(c) } finally { c.close() }
+}
+
+class StringRenderer extends org.clapper.scalasti.AttributeRenderer[String] {
+  def toString(value: String): String = value
+
+  override def toString(value: String, formatName: String): String = {
+    val formats = formatName.split(",").map(_.trim)
+    formats.foldLeft(value)(format)
+  }
+
+  def format(value: String, formatName: String): String = formatName match {
+    case "upper"    | "uppercase"    => value.toUpperCase
+    case "lower"    | "lowercase"    => value.toLowerCase
+    case "cap"      | "capitalize"   => value.capitalize
+    case "decap"    | "decapitalize" => decapitalize(value)
+    case "start"    | "start-case"   => startCase(value)
+    case "word"     | "word-only"    => wordOnly(value)
+    case "Camel"    | "upper-camel"  => upperCamel(value)
+    case "camel"    | "lower-camel"  => lowerCamel(value)
+    case "hyphen"   | "hyphenate"    => hyphenate(value)
+    case "norm"     | "normalize"    => normalize(value)
+    case "packaged" | "package-dir"  => packageDir(value)
+    case _                           => value
+  }
+
+  def decapitalize(s: String) = if (s.isEmpty) s else s(0).toLower + s.substring(1)
+  def startCase(s: String) = s.toLowerCase.split(" ").map(_.capitalize).mkString(" ")
+  def wordOnly(s: String) = s.replaceAll("""\W""", "")
+  def upperCamel(s: String) = wordOnly(startCase(s))
+  def lowerCamel(s: String) = decapitalize(upperCamel(s))
+  def hyphenate(s: String) = s.replaceAll("""\s+""", "-")
+  def normalize(s: String) = hyphenate(s.toLowerCase)
+  def packageDir(s: String) = s.replace(".", System.getProperty("file.separator"))
 }

--- a/plugin/src/main/scala/g8.scala
+++ b/plugin/src/main/scala/g8.scala
@@ -5,7 +5,9 @@ import sbt._
 object G8 {
   import scala.util.control.Exception.allCatch
   import org.clapper.scalasti.StringTemplate
-    
+
+  private val renderer = new StringRenderer
+
   def apply(fromMapping: Seq[(File,String)], toPath: File, parameters: Map[String,String], log: Logger): Seq[File] =
     fromMapping filter { !_._1.isDirectory } flatMap { case (in, relative) =>
       apply(in, expandPath(relative, toPath, parameters), parameters, log)
@@ -18,7 +20,7 @@ object G8 {
       if (verbatim(in, parameters)) IO.copyFile(in, out) 
       else {
         val template = IO.read(in, Charset forName "UTF-8")
-        IO.write(out, new StringTemplate(template).setAttributes(parameters).toString)    
+        IO.write(out, new StringTemplate(template).setAttributes(parameters).registerRenderer(renderer).toString)
       }
     } getOrElse {
       log.info("Unable to parse template %s, copying unmodified" format in)
@@ -48,7 +50,41 @@ object G8 {
         }))
       case x => x
     }: _*)
-    
-    new File(toPath, new StringTemplate(relative).setAttributes(fileParams).toString)
+
+    new File(toPath, new StringTemplate(formatize(relative)).setAttributes(fileParams).registerRenderer(renderer).toString)
   }
+  private def formatize(s: String) = s.replaceAll("""\$(\w+)__(\w+)\$""", """\$$1;format="$2"\$""")
+}
+
+class StringRenderer extends org.clapper.scalasti.AttributeRenderer[String] {
+  def toString(value: String): String = value
+
+  override def toString(value: String, formatName: String): String = {
+    val formats = formatName.split(",").map(_.trim)
+    formats.foldLeft(value)(format)
+  }
+
+  def format(value: String, formatName: String): String = formatName match {
+    case "upper"    | "uppercase"    => value.toUpperCase
+    case "lower"    | "lowercase"    => value.toLowerCase
+    case "cap"      | "capitalize"   => value.capitalize
+    case "decap"    | "decapitalize" => decapitalize(value)
+    case "start"    | "start-case"   => startCase(value)
+    case "word"     | "word-only"    => wordOnly(value)
+    case "Camel"    | "upper-camel"  => upperCamel(value)
+    case "camel"    | "lower-camel"  => lowerCamel(value)
+    case "hyphen"   | "hyphenate"    => hyphenate(value)
+    case "norm"     | "normalize"    => normalize(value)
+    case "packaged" | "package-dir"  => packageDir(value)
+    case _                           => value
+  }
+
+  def decapitalize(s: String) = if (s.isEmpty) s else s(0).toLower + s.substring(1)
+  def startCase(s: String) = s.toLowerCase.split(" ").map(_.capitalize).mkString(" ")
+  def wordOnly(s: String) = s.replaceAll("""\W""", "")
+  def upperCamel(s: String) = wordOnly(startCase(s))
+  def lowerCamel(s: String) = decapitalize(upperCamel(s))
+  def hyphenate(s: String) = s.replaceAll("""\s+""", "-")
+  def normalize(s: String) = hyphenate(s.toLowerCase)
+  def packageDir(s: String) = s.replace(".", System.getProperty("file.separator"))
 }


### PR DESCRIPTION
Use an AttributeRenderer to provide various formatting options.

For example, `name="My Project"` can be rendered in several ways now:

```
$name$ -> "My Project"
$name; format="camel"$ -> "myProject"
$name; format="Camel"$ -> "MyProject"
$name; format="normalized"$ -> "my-project"
$name; format="lower,hyphen"$ -> "my-project"
```

For filenames a format can be specified after double underscore. For example, `$organization__packaged$` will change `org.somewhere` to `org/somewhere` like the built-in support for `package`.

Test project that I tried is here:
https://github.com/pvlugter/formatted-test.g8
