### PR TITLE
make sorting by project name more visible in g8 -l

### DIFF
--- a/app/src/main/scala/discover.scala
+++ b/app/src/main/scala/discover.scala
@@ -11,7 +11,10 @@ trait Discover { self: Giter8 =>
       templates match {
         case Nil => Right("No templates matching %s" format query.get)
         case _ => Right(templates.sortBy { _.name } map { t =>
-          "%-40s%s" format(t.user + "/" + t.name, t.desc)
+          val padding =
+            if (t.name.length < 20 || t.desc == "") ""
+            else "\n                                         "
+          "%20s/%-20s%s%s" format(t.user, t.name, padding, t.desc)
         } mkString("\n"))
       }
     }


### PR DESCRIPTION
By lining up the sorted elements visually, order is injected into the
chaos. Also break lines if the project name is too long; though this
could easily be replaced by a single space if it shall be on one line
always.
