### PR TITLE
Fixing an unwanted 'toString'

### DIFF
--- a/app/src/main/scala/apply.scala
+++ b/app/src/main/scala/apply.scala
@@ -6,14 +6,14 @@ trait Apply { self: Giter8 =>
   import scalax.file.ImplicitConversions.defaultPath2jfile
   import org.eclipse.jgit.api._
   import scala.util.control.Exception.{allCatch,catching}
-  
+
   val tempdir = Path.createTempDirectory(deleteOnExit = true)
 
   def inspect(repo: String,
               branch: Option[String],
-              arguments: Seq[String]) = {
+              arguments: Seq[String]): Either[String, String] = {
     val tmpl = clone(repo, branch)
-    tmpl.right.map(G8Helpers.applyTemplate(_, new File("."), arguments))
+    tmpl.right.flatMap(G8Helpers.applyTemplate(_, new File("."), arguments))
   }
 
   def clone(repo: String, branch: Option[String]) = {
@@ -39,4 +39,3 @@ trait Apply { self: Giter8 =>
     } getOrElse(Right(tempdir))
   }
 }
-

--- a/app/src/main/scala/giter8.scala
+++ b/app/src/main/scala/giter8.scala
@@ -14,11 +14,11 @@ class Giter8 extends xsbti.AppMain with Apply {
   /** Runner shared my main-class runner */
   def run(args: Array[String]): Int = {
     (args.partition { s => Param.pattern.matcher(s).matches } match {
-      case (params, Array(Local(repo))) => 
+      case (params, Array(Local(repo))) =>
         inspect(repo, None, params)
-      case (params, Array(Local(repo), Branch(_), branch)) => 
+      case (params, Array(Local(repo), Branch(_), branch)) =>
         inspect(repo, Some(branch), params)
-      case (params, Array(Git(remote))) => 
+      case (params, Array(Git(remote))) =>
         inspect(remote, None, params)
       case (params, Array(Git(remote), Branch(_), branch)) =>
         inspect(remote, Some(branch), params)
@@ -27,11 +27,11 @@ class Giter8 extends xsbti.AppMain with Apply {
       case (params, Array(Repo(user, proj), Branch(_), branch)) =>
         ghInspect(user, proj, Some(branch), params)
       case _ => Left(usage)
-    }) fold ({ error =>
+    }) fold ({ (error: String) =>
       System.err.println("\n%s\n" format error)
       1
-    }, { message =>
-      println("\n%s\n" format message)
+    }, { (message: String) =>
+      println("\n%s\n" format message )
       0
     })
   }


### PR DESCRIPTION
**Note** I haven't tried this out yet so don't accept this pull request before you teach me how to use my own local version of giter8

After a successful process it would write

```
  Right(Template applied in ./testingthis)
```

to screen. This was due to a `map` that should have been a `flatMap`
resulting in a Right[Nothing, String] where a String was expected.
Because the string was used in a string concatenation toString was
invoked on the Right[Nothing, String] instance.
