### PR TITLE
replace scalasty by stringtemplate 4

### DIFF
--- a/library/src/main/scala/gio.scala
+++ b/library/src/main/scala/gio.scala
@@ -61,4 +61,5 @@ object GIO {
       m + (k.toString -> p.getProperty(k.toString))
     }
   }
+
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -13,7 +13,7 @@ object Builds extends sbt.Build {
     version := g8version,
     scalaVersion := "2.9.1",
     libraryDependencies ++= Seq(
-      "org.clapper" %% "scalasti" % "0.5.5"),
+      "org.antlr" % "stringtemplate" % "4.0.2"),
     publishArtifact in (Compile, packageBin) := true,
     homepage :=
       Some(url("https://github.com/n8han/giter8")),


### PR DESCRIPTION
Hi,

In the current version of g8, scalasti (or StringTemplate 3) is NOT throwing exceptions when an error occur while parsing templates. Using a ErrorListener in scalasti does not solve the issue (because the error happened in constructor, listener is not registered yet).

Since templates are failing silently, binary files (my jars...) are corrupted (g8 creates an empty file).

Scalasti does not support StringTemplate v4 yet (and it does not seems like it will happen soon), so I just replaced it by StringTemplate v4.

Julien.
