### PR TITLE
scaffolding: offer a choice when target file already exists

### DIFF
--- a/library/src/main/scala/gio.scala
+++ b/library/src/main/scala/gio.scala
@@ -36,18 +36,18 @@ object GIO {
     }
     bos.toString(charset)
   }    
-  def copyFile(from: File, to: File) {
+  def copyFile(from: File, to: File, append: Boolean = false) {
     to.getParentFile().mkdirs()
     use(new FIS(from)) { in =>
-      use(new FOS(to)) { out =>
+      use(new FOS(to, append)) { out =>
         transfer(in, out, new Array[Byte](1024*16))
       }
     }
   }
-  def write(to: File, from: String, charset: String) {
+  def write(to: File, from: String, charset: String, append: Boolean = false) {
     to.getParentFile().mkdirs()
     use(new BIS(from.getBytes(charset))) { in =>
-      use(new FOS(to)) { out =>
+      use(new FOS(to, append)) { out =>
         transfer(in, out, new Array[Byte](1024*16))
       }
     }


### PR DESCRIPTION
allow users to choose from one of the following options when target file already exists: Override, Skip, Append.

This can be useful in various scenarios:
- user wants to get rid of existing scaffolding
- user changes his/her mind when seeing that the file already exists
- user wants to append to an existing file instead of overwriting it (in case of play, adding a route definition or a new line to the config file could be such scaffolding )

This patch effects scaffolding only.
