### PR TITLE
Allow to clone non-Github template over https

### DIFF
--- a/app/src/main/scala/apply.scala
+++ b/app/src/main/scala/apply.scala
@@ -16,8 +16,15 @@ trait Apply { self: Giter8 =>
   }
 
   val GitHub = """^([^\s/]+)/([^\s/]+?)(?:\.g8)?$""".r
-  val GitUrl = "^(git[@|://].*)$".r
   val Local = """^file://(\S+)$""".r
+
+  object GitUrl {
+    val NativeUrl = "^(git[@|://].*)$".r
+    val HttpsUrl = "^(https://.*)$".r
+    
+    def unapplySeq(s: Any): Option[List[String]] =
+      NativeUrl.unapplySeq(s) orElse HttpsUrl.unapplySeq(s)
+  }
 
   def inspect(config: Config,
               arguments: Seq[String]): Either[String, String] = {
@@ -29,7 +36,7 @@ trait Apply { self: Giter8 =>
         tmpl.right.flatMap { t =>
           G8Helpers.applyTemplate(t, new File("."), arguments, config.forceOverwrite)
         }
-      case GitUrl(uri) => 
+      case GitUrl(uri) =>
         val tmpl = clone(uri, config)
         tmpl.right.flatMap { t =>
           G8Helpers.applyTemplate(t,


### PR DESCRIPTION
Hi,

I would like to be able to

```
g8 https://my_git_host/my_repo.g8.git
```

The proposed change would seem to do the trick. 

BTW, I'm a bit reluctant to open a "documentation" issue about that, but I actually had a harder time testing the change than writing it. I ended up bumping the version in order to ensure that my fork of g8 was conscripted. Could I have done anything simpler, possibly without having to push to github in order to test?
