### PR TITLE
Docs: update scaffold plugin version references and docs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -306,35 +306,40 @@ Giter8 supplies an sbt plugin for creating and using scaffolds.
 Add the following lines in `project/plugins.sbt`
 
 ```scala
-addSbtPlugin("net.databinder.giter8" % "giter8-scaffold" % "0.4.6-SNAPSHOT")
+addSbtPlugin("net.databinder.giter8" % "giter8-scaffold" % "0.6.8")
 ```
 
-You also want to add `giter8.ScaffoldPlugin.scaffoldSettings` to you project.
+You also need to add `giter8.ScaffoldPlugin.scaffoldSettings` to your project:
 
 ```scala
 lazy val project = Project("project").settings(giter8.ScaffoldPlugin.scaffoldSettings:_*)
 ```
 
-Once done, the  `g8-scaffold` command can be used in the sbt console.
+Once done, the  `g8Scaffold` command can be used in the sbt console.
 Use TAB completion to discover available templates.
 
 ```
-[sample] $ g8-scaffold <TAB>
+[sample] $ g8Scaffold <TAB>
 controller   global       model
 ```
 
 The template plugin will prompt each property that needed to complete the scaffolding process:
 
 ```
-[sample] $ g8-scaffold controller
+[sample] $ g8Scaffold controller
 className [Application]:
 ```
 
 
 ## creating a scaffold
 
-The g8 runtime looks for scaffold in the `src/main/scaffolds`.
-Each folder inside ``src/main/scaffolds` is a different scaffold, and will be accessible in the sbt console using the folder name. 
+The g8 runtime looks for scaffolds in the `src/main/scaffolds`. Each
+folder inside `src/main/scaffolds` is a different scaffold, and will be
+accessible in the sbt console using the folder name. Scaffold folders
+may have a `default.properties` file to define field values, just like
+ordinary templates. `name` is again a special field name: if it exists,
+the scaffold will be generated into a top-level folder based on `name`,
+with subfolders following the layout of the source scaffold folder.
 
 Once a template as been used, scaffolds are stored into `<project_root>/.g8`
 

--- a/sample/project/plugins.sbt
+++ b/sample/project/plugins.sbt
@@ -7,4 +7,4 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("play" % "sbt-plugin" % "2.0.2")
 
-addSbtPlugin("net.databinder.giter8" % "giter8-scaffold" % "0.4.6-SNAPSHOT")
+addSbtPlugin("net.databinder.giter8" % "giter8-scaffold" % "0.6.8")

--- a/scaffold/README.markdown
+++ b/scaffold/README.markdown
@@ -1,7 +1,7 @@
 g8-scaffold
 ======
 
-g8-scaffold add code generation abilities to giter8, after a project has been generated.
+g8-scaffold adds code generation abilities to giter8, after a project has been generated.
 
 Installation
 ------------
@@ -9,7 +9,7 @@ Installation
 You need to add the plugin to your sbt project, in `project/plugins.sbt`
 
 ```scala
-addSbtPlugin("net.databinder.giter8" % "giter8-scaffold" % "0.4.6-SNAPSHOT")
+addSbtPlugin("net.databinder.giter8" % "giter8-scaffold" % "0.6.8")
 ```
 
 Usage
@@ -25,12 +25,12 @@ Generating code
 In the sbt console type:
 
 ```scala
-	g8-scaffold <scaffold_name>
+	g8Scaffold <scaffold_name>
 ```
 
 The name of the scaffold is the name of the folder located directly under `.g8`
 
-Assuming you `.g8` folder has the following structure:
+Assuming your `.g8` folder has the following structure:
 
 ```
 	.g8
@@ -39,7 +39,7 @@ Assuming you `.g8` folder has the following structure:
 	 |_ controller
 ```
 
-You have 3 different scaffodings available.
+You have 3 different scaffoldings available.
 
-To generate a new template, just type `g8-scaffold model`. 
+To generate a new template, just type `g8Scaffold model`. 
 As usual, g8 will ask for the variable values, and generate the correct code.

--- a/scaffold/src/main/scala/scaffolding-plugin.scala
+++ b/scaffold/src/main/scala/scaffolding-plugin.scala
@@ -9,22 +9,22 @@ object ScaffoldPlugin extends sbt.Plugin {
   object ScaffoldingKeys {
     lazy val templatesPath = SettingKey[String]("g8-templates-path")
     lazy val scaffold    = InputKey[Unit]("g8-scaffold",
-      """g8-scaffold add code generation abilities to giter8, after a project has been generated.
+      """g8-scaffold adds code generation abilities to giter8, after a project has been generated.
          |
          |Usage:
-         | g8-scaffold <scaffold_name>
+         | g8Scaffold <scaffold_name>
          |
          |The name of the scaffold is the name of the folder located directly under `.g8`
-         |Assuming you `.g8` folder has the following structure:
+         |Assuming your `.g8` folder has the following structure:
          |
          |    .g8
          |    |_ model
          |    |_ view
          |    |_ controller
          |
-         |You have 3 different scaffodings available.
+         |You have 3 different scaffoldings available.
          |
-         |To generate a new template, just type `g8-scaffold model`.
+         |To generate a new template, just type `g8Scaffold model`.
          |As usual, g8 will ask for the variable values, and generate the correct code.
          |""".stripMargin)
   }


### PR DESCRIPTION
The version referenced was getting quite long in the tooth and isn't even available in SBT default repository sources as far as I could tell, copy-pasting the line from the README was broken out of the box.

While we're at it, I updated references to the `g8-scaffold` SBT command to use camel case since that's what SBT seems to be pushing these days, and it's what autocompletes in the interactive mode. Also fixed some typos and expanded scaffold explanation a little.