### PR TITLE
Support for template delimiter customization

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -184,11 +184,13 @@ The `verbatim` field, if defined, is assumed to be the space delimited
 list of file patterns such as `*.html *.js`. Files matching `verbatim`
 pattern are excluded from string template processing.
 
-The fieds `startDelimiter` and `stopDelimiter` may be used to change
+The fields `startDelimiter` and `stopDelimiter` may be used to change
 default variable delimiters (`$` and `$`).
 An example, using guillemets (» and «):
+
     startDelimiter=»
     stopDelimiter=«
+
 
 ### Formatting template fields
 

--- a/README.markdown
+++ b/README.markdown
@@ -184,6 +184,12 @@ The `verbatim` field, if defined, is assumed to be the space delimited
 list of file patterns such as `*.html *.js`. Files matching `verbatim`
 pattern are excluded from string template processing.
 
+The fieds `startDelimiter` and `stopDelimiter` may be used to change
+default variable delimiters (`$` and `$`).
+An example, using guillemets (» and «):
+    startDelimiter=»
+    stopDelimiter=«
+
 ### Formatting template fields
 
 Giter8 has built-in support for formatting template fields. Formatting options

--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -271,7 +271,7 @@ object G8Helpers {
       println("\n")
     }
 
-    val fixed = Set("verbatim")
+    val fixed = Set("verbatim", "startDelimiter", "stopDelimiter")
     val renderer = new StringRenderer
 
     others.foldLeft(ResolvedProperties.empty) { case (resolved, (k,f)) =>

--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -1,7 +1,9 @@
 package giter8
 
-import java.io.File
-import org.apache.commons.io.FileUtils
+import java.io.{File, InputStreamReader}
+import java.nio.charset.Charset
+
+import org.apache.commons.io.{Charsets, FileUtils}
 import org.apache.commons.io.Charsets.UTF_8
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributes
 import org.codehaus.plexus.logging.Logger
@@ -36,11 +38,13 @@ object G8 {
     * possible to have other ValueF definitions which perform arbitrary logic given previously defined properties.
     */
   type ValueF = ResolvedProperties => String
-  
+
   def applyTemplate(default: String, resolved: ResolvedProperties): String = {
-      val group = STGroup('$', '$')
-      group.registerRenderer(renderer)
-      STHelper(group, default)
+    val start = resolved.get("startDelimiter").flatMap(_.headOption).getOrElse('$')
+    val stop = resolved.get("stopDelimiter").flatMap(_.headOption).getOrElse('$')
+    val group = STGroup(start, stop)
+    group.registerRenderer(renderer)
+    STHelper(group, default)
       .setAttributes(resolved)
       .render()
   }
@@ -99,6 +103,7 @@ object G8 {
 
   def verbatim(file: File, parameters: Map[String,String]): Boolean =
     parameters.get("verbatim") map { s => globMatch(file, s.split(' ').toSeq) } getOrElse {false}
+
   private def globMatch(file: File, patterns: Seq[String]): Boolean =
     patterns exists { globRegex(_).findFirstIn(file.getName).isDefined }
   private def globRegex(pattern: String) = "^%s$".format(pattern flatMap {
@@ -366,7 +371,7 @@ object G8Helpers {
 
   def readProps(stm: java.io.InputStream):G8.OrderedProperties = {
     val p = new LinkedListProperties
-    p.load(stm)
+    p.load(new InputStreamReader(stm, Charsets.UTF_8))
     stm.close()
     (OrderedProperties.empty /: p.keyList) { (l, k) =>
       l :+ (k -> p.getProperty(k))

--- a/src/main/conscript/g8/launchconfig
+++ b/src/main/conscript/g8/launchconfig
@@ -1,5 +1,5 @@
 [app]
-  version: 0.6.8
+  version: 0.6.9-SNAPSHOT
   org: net.databinder.giter8
   name: giter8
   class: giter8.Giter8

--- a/src/main/conscript/g8/launchconfig
+++ b/src/main/conscript/g8/launchconfig
@@ -1,6 +1,6 @@
 [app]
   version: 0.6.9-SNAPSHOT
-  org: net.databinder.giter8
+  org: org.foundweekends.giter8
   name: giter8
   class: giter8.Giter8
 [scala]


### PR DESCRIPTION
Currently, giter8 only supports $...$ for variable definitions.
Especially for projects holding a bunch of bash scripts, or ruby, or Scala with s".${asdf}." string expansion, this is not always desirable.
Setting the delimiters in default.properties makes it easier to use giter8 in these scenarios.

One caveat is that the properties file really should be UTF8-encoded to make it easy to use rarely used characters as delimiters. This might break backward compatibility.