### PR TITLE
fix for issue #73 -- better error handling when templates do not compile

### DIFF
--- a/app/src/main/scala/apply.scala
+++ b/app/src/main/scala/apply.scala
@@ -1,7 +1,8 @@
 package giter8
 
 import org.eclipse.jgit.transport._
-  
+import org.stringtemplate.v4.compiler.STException
+
 trait Apply { self: Giter8 =>
   import java.io.File
   import org.apache.commons.io.FileUtils
@@ -48,12 +49,12 @@ trait Apply { self: Giter8 =>
           clone(path, config)
         }.getOrElse(copy(path))
         tmpl.right.flatMap { t =>
-          G8Helpers.applyTemplate(t, new File("."), arguments, config.forceOverwrite)
+          applyTemplate(t, new File("."), arguments, config.forceOverwrite)
         }
       case GitUrl(uri) =>
         val tmpl = clone(uri, config)
         tmpl.right.flatMap { t =>
-          G8Helpers.applyTemplate(t,
+          applyTemplate(t,
             new File("."),
             arguments,
             config.forceOverwrite
@@ -75,6 +76,23 @@ trait Apply { self: Giter8 =>
             cleanup()
             inspect(privateConfig, arguments)
         }
+    }
+  }
+
+  def applyTemplate(
+    tmpl: File,
+    outputFolder: File,
+    arguments: Seq[String] = Nil,
+    forceOverwrite: Boolean = false
+  ) = {
+    try {
+      G8Helpers.applyTemplate(tmpl, outputFolder, arguments, forceOverwrite)
+    }
+    catch {
+      case e: STException =>
+        Left(s"Exiting due to error in the template\n${e.getMessage}")
+      case t : Throwable =>
+        Left("Unknown exception: " + t.getMessage)
     }
   }
 

--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -50,16 +50,16 @@ object G8 {
 
   class STErrorHandler extends STErrorListener {
     def compileTimeError(msg: STMessage) = {
-      throw new Exception("Template Compile Time Error")
+      throw new STException(msg.toString, null)
     }
     def runTimeError(msg: STMessage) = {
-      throw new Exception("Template Run Time Error")
+      throw new STException(msg.toString, null)
     }
     def IOError(msg: STMessage) = {
-      throw new Exception("Template IO Time Error")
+      throw new STException(msg.toString, null)
     }
     def internalError(msg: STMessage) = {
-      throw new Exception("Template Internal Error")
+      throw new STException(msg.toString, null)
     }
   }
 
@@ -107,14 +107,16 @@ object G8 {
           write(out, FileUtils.readFileToString(in, "UTF-8"), parameters, append)
           util.Try(ArchiveEntryUtils.chmod(out, mode, new ConsoleLogger(Logger.LEVEL_ERROR, "")))
         case None =>
-            // PlexusIoResourceAttributes is not available for some OS'es such as windows
-            write(out, FileUtils.readFileToString(in, "UTF-8"), parameters, append)
+          // PlexusIoResourceAttributes is not available for some OS'es such as windows
+          write(out, FileUtils.readFileToString(in, "UTF-8"), parameters, append)
       }
     }
     catch {
+      case e : STException =>
+        // add the current file to the exception for debugging purposes
+        throw new STException(s"File: $in, ${e.getMessage}", null)
       case t : Throwable =>
-        println("Falling back to file copy for %s: %s" format(in.toString, t.getMessage))
-        FileUtils.copyFile(in, out)
+        throw t
     }
   }
 


### PR DESCRIPTION
What do you guys think about this? This will _at least_ catch the error and so something instead of just leaving a stack trace in the console.

Example
```
> g8 'file:////Users/njlg/source/tmp/my-template-project' --name='Web Services'
Falling back to file copy for /var/folders/_3/8pkvrys57l7126tsxy8bklfm000cdh/T/giter8-474632438671134/src/main/g8/app/com/webservices/api/$name__snake$/filters/AccessLog.scala: Template Compile Time Error

Template applied in ./web-services
```