### PR TITLE
root layout

### DIFF
--- a/app/src/main/scala/giter8.scala
+++ b/app/src/main/scala/giter8.scala
@@ -17,7 +17,7 @@
 
 package giter8
 
-class Giter8 extends xsbti.AppMain with Apply {
+class Giter8 extends xsbti.AppMain {
   java.util.logging.Logger.getLogger("").setLevel(java.util.logging.Level.SEVERE)
 
   /** The launched conscript entry point */
@@ -31,11 +31,11 @@ class Giter8 extends xsbti.AppMain with Apply {
     } match {
       case (params, options) =>
         parser.parse(options, Config()).map { config =>
-          inspect(config, params)
+          JgitHelper.run(config, params)
         }.getOrElse(Left(""))
       case _ => Left(parser.usage)
     })
-    cleanup()
+    JgitHelper.cleanup()
     result.fold ({ (error: String) =>
       System.err.println(s"\n$error\n")
       1

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,8 @@ lazy val root = (project in file(".")).
       publishArtifact in Test := false,
       licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
       developers := List(
-        Developer("n8han", "Nathan Hamblen", "@n8han", url("http://github.com/n8han"))
+        Developer("n8han", "Nathan Hamblen", "@n8han", url("http://github.com/n8han")),
+        Developer("eed3si9n", "Eugene Yokota", "@eed3si9n", url("https://github.com/eed3si9n"))
       ),
       scmInfo := Some(ScmInfo(url("https://github.com/foundweekends/giter8"), "git@github.com:foundweekends/giter8.git"))
     )),
@@ -36,7 +37,7 @@ lazy val app = (project in file("app")).
     description := "Command line tool to apply templates defined on github",
     name := "giter8",
     sourceDirectory in csRun := { (baseDirectory).value.getParentFile / "src" / "main" / "conscript" },
-    libraryDependencies ++= Seq(jgit, scopt),
+    libraryDependencies ++= Seq(scopt),
     buildInfoKeys := Seq(name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "giter8"
   )
@@ -71,7 +72,7 @@ lazy val lib = (project in file("library")).
     name := "giter8-lib",
     description := "shared library for app and plugin",
     libraryDependencies ++= Seq(
-      scalasti, jline, httpClient, commonsIo, plexusArchiver,
+      scalasti, jline, jgit, httpClient, commonsIo, plexusArchiver,
       scalacheck % Test, sbtIo % Test
     )
   )

--- a/library/src/main/scala/JgitHelper.scala
+++ b/library/src/main/scala/JgitHelper.scala
@@ -85,6 +85,14 @@ object JgitHelper {
             )
             cleanup()
             run(privateConfig, arguments)
+          // The following code can fallback to non-g8 repo, but because
+          // of the stringtemplate's $, it's not like you can just point at any repo.
+          // case _: org.eclipse.jgit.api.errors.TransportException =>
+          //   val nonG8Config = config.copy(
+          //     repo = "git://github.com/%s/%s.git".format(user, proj)
+          //   )
+          //   cleanup()
+          //   run(nonG8Config, arguments)
         }
     }
   }

--- a/library/src/main/scala/JgitHelper.scala
+++ b/library/src/main/scala/JgitHelper.scala
@@ -20,7 +20,7 @@ package giter8
 import org.eclipse.jgit.transport._
 import org.stringtemplate.v4.compiler.STException
 
-trait Apply { self: Giter8 =>
+object JgitHelper {
   import java.io.File
   import org.apache.commons.io.FileUtils
   import org.eclipse.jgit.api._
@@ -51,7 +51,7 @@ trait Apply { self: Giter8 =>
       SshUrl.unapplySeq(s)
   }
 
-  def inspect(config: Config,
+  def run(config: Config,
               arguments: Seq[String]): Either[String, String] = {
     config.repo match {
       case Local(path) =>
@@ -59,12 +59,12 @@ trait Apply { self: Giter8 =>
           clone(path, config)
         }.getOrElse(copy(path))
         tmpl.right.flatMap { t =>
-          applyTemplate(t, new File("."), arguments, config.forceOverwrite)
+          G8Helpers.applyTemplate(t, new File("."), arguments, config.forceOverwrite)
         }
       case GitUrl(uri) =>
         val tmpl = clone(uri, config)
         tmpl.right.flatMap { t =>
-          applyTemplate(t,
+          G8Helpers.applyTemplate(t,
             new File("."),
             arguments,
             config.forceOverwrite
@@ -75,7 +75,7 @@ trait Apply { self: Giter8 =>
           val publicConfig = config.copy(
             repo = "git://github.com/%s/%s.g8.git".format(user, proj)
           )
-          inspect(publicConfig, arguments)
+          run(publicConfig, arguments)
         } catch {
           case _: org.eclipse.jgit.api.errors.JGitInternalException =>
             // assume it was an access failure, try with ssh
@@ -84,25 +84,8 @@ trait Apply { self: Giter8 =>
               repo = "git@github.com:%s/%s.g8.git".format(user, proj)
             )
             cleanup()
-            inspect(privateConfig, arguments)
+            run(privateConfig, arguments)
         }
-    }
-  }
-
-  def applyTemplate(
-    tmpl: File,
-    outputFolder: File,
-    arguments: Seq[String] = Nil,
-    forceOverwrite: Boolean = false
-  ) = {
-    try {
-      G8Helpers.applyTemplate(tmpl, outputFolder, arguments, forceOverwrite)
-    }
-    catch {
-      case e: STException =>
-        Left(s"Exiting due to error in the template\n${e.getMessage}")
-      case t : Throwable =>
-        Left("Unknown exception: " + t.getMessage)
     }
   }
 

--- a/notes/0.7.0.markdown
+++ b/notes/0.7.0.markdown
@@ -1,0 +1,8 @@
+### root layout
+
+giter8 0.7.0 introduces a new template layout called *root layout*.
+When giter8 does not find `src/main/g8`, it will simply use the root directory
+of the specified Git repository as the template directory.
+
+The `default.properties` file can be placed either at the root directory
+or in `project` directory.


### PR DESCRIPTION
This introduces a new template layout called *root layout*. When giter8 does not find `src/main/g8`, it will simply use the root directory of the specified Git repository as the template directory, skipping some files like the content of `.git` directory.

The `default.properties` file can now be placed either at the root directory or in `project` directory.

Due to string template (which uses `%` to denote variables), the idea that pointing giter8 to a random git repository and expecting it to work would be too optimistic. However, the root layout still makes it easier to navigate around using Github. See https://github.com/eed3si9n/hello.g8

Fixes #200
