### PR TITLE
fix after_success commands. check $TRAVIS_REPO_SLUG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ before_script:
  - export JVM_OPTS="-Xms1024m -Xmx1024m -XX:ReservedCodeCacheSize=128m -XX:MaxPermSize=256m -Xss2m -Dfile.encoding=UTF-8"
 
 after_success:
-- test $TRAVIS_PULL_REQUEST == "false" && eval "$(ssh-agent -s)" #start the ssh agent
-- test $TRAVIS_PULL_REQUEST == "false" && openssl aes-256-cbc -K $encrypted_e5f9765ae931_key -iv $encrypted_e5f9765ae931_iv -in deploy_rsa.enc -out deploy_rsa -d
-- test $TRAVIS_PULL_REQUEST == "false" && chmod 600 deploy_rsa
-- test $TRAVIS_PULL_REQUEST == "false" && ssh-add deploy_rsa
-- test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "0.7.x" && sbt pushSiteIfChanged
+- if [[ "${TRAVIS_PULL_REQUEST}" == "false" && "${TRAVIS_BRANCH}" == "0.7.x" && "${TRAVIS_REPO_SLUG}" == "foundweekends/giter8" ]]; then export PUBLISH_SITE=true; fi
+- test "${PUBLISH_SITE}" == "true" && eval "$(ssh-agent -s)" #start the ssh agent
+- test "${PUBLISH_SITE}" == "true" && openssl aes-256-cbc -K $encrypted_e5f9765ae931_key -iv $encrypted_e5f9765ae931_iv -in deploy_rsa.enc -out deploy_rsa -d
+- test "${PUBLISH_SITE}" == "true" && chmod 600 deploy_rsa
+- test "${PUBLISH_SITE}" == "true" && ssh-add deploy_rsa
+- test "${PUBLISH_SITE}" == "true" && sbt pushSiteIfChanged


### PR DESCRIPTION
I want to enable travis-ci in my fork repository.
But travis fail with the after_success command.

```
$ test $TRAVIS_PULL_REQUEST == "false" && ssh-add deploy_rsa
Enter passphrase for deploy_rsa:

No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

The build has been terminated
```

The $TRAVIS_REPO_SLUG variable is

> The slug (in form: owner_name/repo_name) of the repository currently being built. (for example, “travis-ci/travis-build”).

https://docs.travis-ci.com/user/environment-variables/