### PR TITLE
Fix access to private repos

### DIFF
--- a/library/src/main/scala/JgitHelper.scala
+++ b/library/src/main/scala/JgitHelper.scala
@@ -77,7 +77,7 @@ object JgitHelper {
           )
           run(publicConfig, arguments)
         } catch {
-          case _: org.eclipse.jgit.api.errors.JGitInternalException =>
+          case _: org.eclipse.jgit.api.errors.TransportException =>
             // assume it was an access failure, try with ssh
             // after cleaning the clone directory
             val privateConfig = config.copy(


### PR DESCRIPTION
The exception type caught did not match the one returned in the case of a failure to fetch a private repository (TransportException).