### PR TITLE
use JavaConverters instead of JavaConversions

### DIFF
--- a/plugin/src/main/scala/gio.scala
+++ b/plugin/src/main/scala/gio.scala
@@ -20,11 +20,11 @@ package giter8
 object GIO {
 
   def readProps(stm: java.io.InputStream) = {
-    import scala.collection.JavaConversions._
+    import scala.collection.JavaConverters._
     val p = new java.util.Properties
     p.load(stm)
     stm.close()
-    (Map.empty[String, String] /: p.propertyNames) { (m, k) =>
+    p.propertyNames.asScala.foldLeft(Map.empty[String, String]) { (m, k) =>
       m + (k.toString -> p.getProperty(k.toString))
     }
   }


### PR DESCRIPTION
JavaConversions is deprecated since Scala 2.12
https://github.com/scala/scala/blob/v2.12.1/src/library/scala/collection/JavaConversions.scala#L59