### PR TITLE
avoid deprecated `def unapplySeq(target: Any)`

### DIFF
--- a/library/src/main/scala/JgitHelper.scala
+++ b/library/src/main/scala/JgitHelper.scala
@@ -44,7 +44,7 @@ object JgitHelper {
     val HttpUrl = "^(http://.*)$".r
     val SshUrl = "^(ssh://.*)$".r
 
-    def unapplySeq(s: Any): Option[List[String]] =
+    def unapplySeq(s: CharSequence): Option[List[String]] =
       NativeUrl.unapplySeq(s) orElse
       HttpsUrl.unapplySeq(s) orElse
       HttpUrl.unapplySeq(s) orElse


### PR DESCRIPTION
use `def unapplySeq(s: CharSequence)`

- https://github.com/scala/scala/blob/v2.12.1/src/library/scala/util/matching/Regex.scala#L261
- https://github.com/scala/scala/blob/v2.12.1/src/library/scala/util/matching/Regex.scala#L326