### PR TITLE
Issue #123: Respect .gitignore

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,7 @@ lazy val lib = (project in file("library")).
     crossScalaVersions := List(scala210, scala211, scala212),
     libraryDependencies ++= Seq(
       scalasti, jgit, commonsIo, plexusArchiver,
-      scalacheck % Test, sbtIo % Test
+      scalacheck % Test, sbtIo % Test, scalatest % Test
     ) ++
     (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>

--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -230,7 +230,7 @@ object G8 {
       val skipFiles: Set[File] = gitFiles ++ pluginFiles ++ metadata ++ testFiles
       val xs = getFiles(x => {
         val p = x.toURI.toASCIIString
-        !skipFiles(x) && !p.contains("/target/")
+        !skipFiles(x) && !p.stripPrefix(baseDirectory.toURI.toASCIIString).contains("target/")
       })(root)
       xs
     }

--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -228,9 +228,12 @@ object G8 {
       val testFiles = baseAndMeta("test", "giter8.test", "g8.test")
       // .git and other files
       val skipFiles: Set[File] = gitFiles ++ pluginFiles ++ metadata ++ testFiles
+      val gitignoreFile: File = getFiles(_ => true)(root / ".gitignore").head
+      val ignores = if (gitignoreFile.exists) Some(JGitIgnore(gitignoreFile)) else None
       val xs = getFiles(x => {
         val p = x.toURI.toASCIIString
-        !skipFiles(x) && !p.stripPrefix(baseDirectory.toURI.toASCIIString).contains("target/")
+        val isIgnored = ignores.isDefined && ignores.get.isIgnored(p)
+        !isIgnored && !skipFiles(x) && !p.stripPrefix(baseDirectory.toURI.toASCIIString).contains("target/")
       })(root)
       xs
     }

--- a/library/src/test/resources/testcases/simple-sbt-project/output/example-sbt-project/build.sbt
+++ b/library/src/test/resources/testcases/simple-sbt-project/output/example-sbt-project/build.sbt
@@ -1,0 +1,3 @@
+name := "Example SBT project"
+
+scalaVersion := "2.11.5"

--- a/library/src/test/resources/testcases/simple-sbt-project/output/example-sbt-project/project/build.properties
+++ b/library/src/test/resources/testcases/simple-sbt-project/output/example-sbt-project/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.11.3

--- a/library/src/test/resources/testcases/simple-sbt-project/output/example-sbt-project/src/main/scala/com/example/Main.scala
+++ b/library/src/test/resources/testcases/simple-sbt-project/output/example-sbt-project/src/main/scala/com/example/Main.scala
@@ -1,0 +1,5 @@
+package com.example
+
+object Main extends App {
+  println("Hello from project Example SBT project")
+}

--- a/library/src/test/resources/testcases/simple-sbt-project/template/src/main/g8/build.sbt
+++ b/library/src/test/resources/testcases/simple-sbt-project/template/src/main/g8/build.sbt
@@ -1,0 +1,3 @@
+name := "$name$"
+
+scalaVersion := "2.11.5"

--- a/library/src/test/resources/testcases/simple-sbt-project/template/src/main/g8/default.properties
+++ b/library/src/test/resources/testcases/simple-sbt-project/template/src/main/g8/default.properties
@@ -1,0 +1,2 @@
+name = Example SBT project
+package=com.example

--- a/library/src/test/resources/testcases/simple-sbt-project/template/src/main/g8/project/build.properties
+++ b/library/src/test/resources/testcases/simple-sbt-project/template/src/main/g8/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.11.3

--- a/library/src/test/resources/testcases/simple-sbt-project/template/src/main/g8/src/main/scala/$package$/Main.scala
+++ b/library/src/test/resources/testcases/simple-sbt-project/template/src/main/g8/src/main/scala/$package$/Main.scala
@@ -1,0 +1,5 @@
+package $package$
+
+object Main extends App {
+  println("Hello from project $name$")
+}

--- a/library/src/test/scala/giter8/IntegrationTest.scala
+++ b/library/src/test/scala/giter8/IntegrationTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import G8._
 
 class IntegrationTest extends FlatSpec with IntegrationTestHelpers with Matchers {
-  "Giter8" should "treat sorces root as template root" in testCase { case (template, expected, actual) =>
+  "Giter8" should "treat sources root as template root" in testCase { case (template, expected, actual) =>
     "I am foo.txt" >> (template / "foo.txt")
     "I am foo.txt" >> (expected / "foo.txt")
     checkGeneratedProject(template, expected, actual)
@@ -78,7 +78,7 @@ class IntegrationTest extends FlatSpec with IntegrationTestHelpers with Matchers
 
   ignore should "read default.properties from sbt project directory" in testCase { case (template, expected, actual) =>
     "foo = bar" >> (template / "project" / "default.properties")
-    "$foo$" >> (template / "src" / "main" / "g8" /  "foo.txt")
+    "$foo$" >> (template / "src" / "main" / "g8" / "foo.txt")
     "bar" >> (expected / "foo.txt")
     checkGeneratedProject(template, expected, actual)
   }
@@ -97,6 +97,24 @@ class IntegrationTest extends FlatSpec with IntegrationTestHelpers with Matchers
 
     "package $package$" >> (template / "src/main/g8/src/main/scala" / "$package$" / "Main.scala")
     "package com.example" >> (expected / "package-test" / "src/main/scala" / "com/example" / "Main.scala")
+    checkGeneratedProject(template, expected, actual)
+  }
+
+  it should "respect .gitignore in template root" in testCase { case (template, expected, actual) =>
+    val gitignore =
+      """|foo.txt
+         |*.test
+         |.idea/
+         |.DS_Store
+      """.stripMargin
+    gitignore >> (template / "src" / "main" / "g8" / ".gitignore")
+    gitignore >> (expected / ".gitignore")
+
+    touch(template / "src" / "main" / "g8" / "foo.txt")
+    touch(template / "src" / "main" / "g8" / "bar.test")
+    touch(template / "src" / "main" / "g8" / ".DS_Store")
+    touch(template / "src" / "main" / "g8" / "folder" / ".DS_Store")
+    touch(template / "src" / "main" / "g8" / ".idea" / "ignoreMe")
     checkGeneratedProject(template, expected, actual)
   }
 
@@ -129,4 +147,5 @@ class IntegrationTest extends FlatSpec with IntegrationTestHelpers with Matchers
       }
     }
   }
+
 }

--- a/library/src/test/scala/giter8/IntegrationTest.scala
+++ b/library/src/test/scala/giter8/IntegrationTest.scala
@@ -1,0 +1,132 @@
+package giter8
+
+import java.io.{File, PrintWriter}
+
+import org.scalatest.{FlatSpec, Matchers}
+import G8._
+
+class IntegrationTest extends FlatSpec with IntegrationTestHelpers with Matchers {
+  "Giter8" should "treat sorces root as template root" in testCase { case (template, expected, actual) =>
+    "I am foo.txt" >> (template / "foo.txt")
+    "I am foo.txt" >> (expected / "foo.txt")
+    checkGeneratedProject(template, expected, actual)
+  }
+
+  it should "treat src/main/g8 as template root" in testCase { case (template, expected, actual) =>
+    "I am foo.txt" >> (template / "src" / "main" / "g8" / "foo.txt")
+    "I am foo.txt" >> (expected / "foo.txt")
+    checkGeneratedProject(template, expected, actual)
+  }
+
+  it should "prefer src/main/g8 over sources root" in testCase { case (template, expected, actual) =>
+    "I am foo.txt" >> (template / "foo.txt")
+    "I am bar.txt" >> (template / "src" / "main" / "g8" / "bar.txt")
+    "I am bar.txt" >> (expected / "bar.txt")
+    checkGeneratedProject(template, expected, actual)
+  }
+
+  it should "ignore empty directories" in testCase { case (template, expected, actual) =>
+    mkdir(template / "empty")
+    mkdir(template / "src" / "main" / "g8" / "empty")
+    checkGeneratedProject(template, expected, actual)
+  }
+
+  it should "ignore .git folder" in testCase { case (template, expected, actual) =>
+    touch(template / ".git" / "ignoreMe")
+    checkGeneratedProject(template, expected, actual)
+  }
+
+  it should "ignore plugin files" in testCase { case (template, expected, actual) =>
+    touch(template / "giter8.sbt")
+    touch(template / "g8.sbt")
+    touch(template / "project" / "giter8.sbt")
+    touch(template / "project" / "g8.sbt")
+    checkGeneratedProject(template, expected, actual)
+  }
+
+  it should "ignore metadata files" in testCase { case (template, expected, actual) =>
+    touch(template / "activator.properties")
+    touch(template / "template.properties")
+    touch(template / "project" / "activator.properties")
+    touch(template / "project" / "template.properties")
+    checkGeneratedProject(template, expected, actual)
+  }
+
+  it should "ignore test files" in testCase { case (template, expected, actual) =>
+    touch(template / "test")
+    touch(template / "giter8.test")
+    touch(template / "g8.test")
+    touch(template / "project" / "test")
+    touch(template / "project" / "giter8.test")
+    touch(template / "project" / "g8.test")
+    checkGeneratedProject(template, expected, actual)
+  }
+
+  it should "ignore 'target' directories" in testCase { case (template, expected, actual) =>
+    touch(template / "target" / "ignoreMe")
+    touch(template / "project" / "target" / "ignoreMe")
+    touch(template / "src" / "main" / "g8" / "target" / "ignoreMe")
+    checkGeneratedProject(template, expected, actual)
+  }
+
+  it should "read default.properties from template root" in testCase { case (template, expected, actual) =>
+    "foo = bar" >> (template / "src" / "main" / "g8" / "default.properties")
+    "$foo$" >> (template / "src" / "main" / "g8" / "foo.txt")
+    "bar" >> (expected / "foo.txt")
+    checkGeneratedProject(template, expected, actual)
+  }
+
+  ignore should "read default.properties from sbt project directory" in testCase { case (template, expected, actual) =>
+    "foo = bar" >> (template / "project" / "default.properties")
+    "$foo$" >> (template / "src" / "main" / "g8" /  "foo.txt")
+    "bar" >> (expected / "foo.txt")
+    checkGeneratedProject(template, expected, actual)
+  }
+
+  it should "create directory with project name" in testCase { case (template, expected, actual) =>
+    "name = My awesome Project" >> (template / "src" / "main" / "g8" / "default.properties")
+    "This is $name$" >> (template / "src" / "main" / "g8" / "foo.txt")
+    "This is My awesome Project" >> (expected / "my-awesome-project" / "foo.txt")
+    checkGeneratedProject(template, expected, actual)
+  }
+
+  it should "resolve package names" in testCase { case (template, expected, actual) =>
+    """|name = Package test
+       |package = com.example
+    """.stripMargin >> (template / "src" / "main" / "g8" / "default.properties")
+
+    "package $package$" >> (template / "src/main/g8/src/main/scala" / "$package$" / "Main.scala")
+    "package com.example" >> (expected / "package-test" / "src/main/scala" / "com/example" / "Main.scala")
+    checkGeneratedProject(template, expected, actual)
+  }
+
+  private def testCase(test: (File, File, File) => Unit): Unit = {
+    inTempDirectory { tmp =>
+      val templateDir = mkdir(tmp / "template")
+      val outputDir = mkdir(tmp / "output")
+      val actualDir = mkdir(tmp / "actual")
+      test(templateDir, outputDir, actualDir)
+    }
+  }
+
+  private def mkdir(dir: File): File = {
+    if (dir.exists()) throw new Exception(s"${dir.getAbsolutePath} already exists")
+    if (!dir.mkdirs()) throw new Exception(s"Cannot create ${dir.getAbsolutePath}")
+    else dir
+  }
+
+  private def touch(file: File): Unit = if (!file.exists) {
+    file.getParentFile.mkdirs()
+    file.createNewFile()
+  }
+
+  implicit class WriteableString(s: String) {
+    def >>(file: File): Unit = {
+      touch(file)
+      new PrintWriter(file) {
+        write(s)
+        close()
+      }
+    }
+  }
+}

--- a/library/src/test/scala/giter8/IntegrationTestHelpers.scala
+++ b/library/src/test/scala/giter8/IntegrationTestHelpers.scala
@@ -1,0 +1,83 @@
+package giter8
+
+import java.io.{File, InputStream}
+
+import org.apache.commons.io.FileUtils
+import org.scalatest.Assertions.fail
+
+import scala.io.Source
+
+trait IntegrationTestHelpers {
+  def checkGeneratedProject(template: File, expected: File, actual: File): Unit = {
+    Console.withIn(InfiniteLineBreaks) {
+      G8.fromDirectory(template, actual, Seq.empty, forceOverwrite = false) match {
+        case Right(_) => compareDirectories(actual, expected)
+        case Left(err) => fail(err)
+      }
+    }
+  }
+
+  object InfiniteLineBreaks extends InputStream {
+    override def read(): Int = '\n'.toByte
+  }
+
+  def inTempDirectory(code: File => Unit): Unit = {
+    val tempDir = new File(FileUtils.getTempDirectory, "g8test-" + System.nanoTime)
+    tempDir.mkdirs()
+    code(tempDir)
+    tempDir.delete()
+  }
+
+  def compareDirectories(actual: File, expected: File): Unit = {
+    compareDirectoryContents(actual, expected)
+    compareFiles(actual, expected)
+  }
+
+  private def compareDirectoryContents(actual: File, expected: File): Unit = {
+    val expectedFiles = getFiles(expected).keySet
+    val actualFiles = getFiles(actual).keySet
+
+    val missingFiles = expectedFiles.diff(actualFiles)
+    val missing = if (missingFiles.nonEmpty) s"Missing files:\n\t${missingFiles.mkString("\n\t")}\n" else ""
+
+    val extraFiles = actualFiles.diff(expectedFiles)
+    val extra = if (extraFiles.nonEmpty) s"Extra files:\n\t${extraFiles.mkString("\n\t")}\n" else ""
+
+    val result = missing + extra
+    if (result.nonEmpty) fail(s"$result")
+  }
+
+  private def compareFiles(actual: File, expected: File): Unit = {
+    val expectedFiles = getFiles(expected)
+    val actualFiles = getFiles(actual)
+    actualFiles foreach { case (path, file) =>
+      compareFileContents(path, file, expectedFiles(path))
+    }
+  }
+
+  private def compareFileContents(path: String, actual: File, expected: File): Unit = {
+    val actualLines = Source.fromFile(actual).getLines().toSeq
+    val expectedLines = Source.fromFile(expected).getLines().toSeq
+    expectedLines.zipWithIndex foreach { case (line, i) =>
+      assert(line == actualLines(i), s"in file $path:$i")
+    }
+  }
+
+  private def getFiles(baseDir: File): Map[String, File] = {
+    mapWithRelativePaths(getFilesRecursively(baseDir), baseDir)
+  }
+
+  private def mapWithRelativePaths(files: Seq[File], baseDir: File): Map[String, File] = {
+    val pairs = files.map(f => getRelativePath(f, baseDir) -> f)
+    Map(pairs: _*)
+  }
+
+  private def getRelativePath(file: File, baseDirectory: File): String = {
+    file.getAbsolutePath.stripPrefix(baseDirectory.getAbsolutePath)
+  }
+
+  private def getFilesRecursively(file: File): Seq[File] = file match {
+    case dir if file.isDirectory => dir.listFiles.flatMap(getFilesRecursively)
+    case _ => Seq(file)
+  }
+}

--- a/library/src/test/scala/giter8/JGitIgnoreTest.scala
+++ b/library/src/test/scala/giter8/JGitIgnoreTest.scala
@@ -1,0 +1,36 @@
+package giter8
+
+import java.io.ByteArrayInputStream
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class JGitIgnoreTest extends FlatSpec with Matchers {
+  "JGitIgnore" can "be created from Seq of string patterns" in {
+    val patterns = Seq(".test")
+    JGitIgnore(patterns).getPatterns should contain theSameElementsAs patterns
+  }
+
+  it can "be created from InputStream" in {
+    val patterns = Seq(".test")
+    val stream = new ByteArrayInputStream(patterns.mkString("\n").getBytes())
+    JGitIgnore(stream).getPatterns should contain theSameElementsAs patterns
+  }
+
+  it should "check if file is ignored" in {
+    val ignore = JGitIgnore(Seq("iAmIgnored"))
+    ignore.isIgnored("notIgnored") shouldBe false
+    ignore.isIgnored("iAmIgnored") shouldBe true
+  }
+
+  it should "support wildcards" in {
+    val ignore = JGitIgnore(Seq("*.test"))
+    ignore.isIgnored("foo.test") shouldBe true
+    ignore.isIgnored("bar.test") shouldBe true
+  }
+
+  it should "support nested directories" in {
+    val ignore = JGitIgnore(Seq("*.test"))
+    ignore.isIgnored("foo/foo.test") shouldBe true
+    ignore.isIgnored("bar/bar.test") shouldBe true
+  }
+}

--- a/library/src/test/scala/giter8/SampleTemplatesIntegrationTest.scala
+++ b/library/src/test/scala/giter8/SampleTemplatesIntegrationTest.scala
@@ -1,0 +1,25 @@
+package giter8
+
+import java.io.File
+
+import org.scalatest.FunSuite
+import G8._
+
+class SampleTemplatesIntegrationTest extends FunSuite with IntegrationTestHelpers {
+  case class TestCase(name: String, template: File, output: File)
+
+  val testCases: Seq[TestCase] = {
+    val testCasesDirectory = new File(getClass.getResource("/testcases").getPath)
+    testCasesDirectory.listFiles map { testCase =>
+      TestCase(testCase.getName, testCase / "template", testCase / "output")
+    }
+  }
+
+  testCases foreach { testCase =>
+    test(s"Test template: '${testCase.name}'") {
+      inTempDirectory { tmp =>
+        checkGeneratedProject(testCase.template, testCase.output, tmp)
+      }
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,7 @@ object Dependencies {
   val jgit = "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.7.0.201502260915-r"
   val scopt = "com.github.scopt" %% "scopt" % "3.5.0"
   val scalacheck = "org.scalacheck" %% "scalacheck" % "1.13.4"
+  val scalatest = "org.scalatest" %% "scalatest" % "3.0.1"
   val sbtIo = "org.scala-sbt" %% "io" % "1.0.0-M7"
   val scala210 = "2.10.6"
   val scala211 = "2.11.8"


### PR DESCRIPTION
This PR adds fixes #123, as well as some integration tests.

Test suite can be extended 
- either with adding more example template directories to `test/resouces/testcases` with `template` and sample `output` folders;
- or with simple test with convenient file DSL to `IntegrationTest` class.

There was one fix to `templateFiles` function to ignore paths containing `target`. Before commit any path with `target` was ignored. Now giter8 will ignore only `target` diectories inside base template directory.

Also, `scalatest` was added to dependencies.