### PR TITLE
Fix dollar sign issue in documentation

### DIFF
--- a/docs/05.md
+++ b/docs/05.md
@@ -13,7 +13,7 @@ to try out your changes before you open a pull request. This is how you do it.
 Giter8 uses [conscript] as distribution mechanism. You can find more documentation
 about conscript on its [official page].
 
-#### Fixing $PATH:
+#### Fixing `PATH`:
 
 Before you install giter8 with conscript, you need to ensure, that
 conscript directory has higher precedence than default installation path.


### PR DESCRIPTION
This PR fixes dollar sign issue in "Fixing $PATH" header on http://www.foundweekends.org/giter8/contributing.html.
![image](https://cloud.githubusercontent.com/assets/5107532/22997861/851e4bc4-f3d4-11e6-9c06-f3e63aea7d95.png)
