### PR TITLE
Add an optional baseDirectory parameter to run()

### DIFF
--- a/app/src/main/scala/giter8.scala
+++ b/app/src/main/scala/giter8.scala
@@ -27,14 +27,14 @@ class Giter8 extends xsbti.AppMain {
     new Exit(Giter8.run(config.arguments))
 
   /** Runner shared my main-class runner */
-  def run(args: Array[String]): Int = {
+  def run(args: Array[String], baseDirectory: File): Int = {
     val helper = new JgitHelper(new Git(new JGitInteractor), G8TemplateRenderer)
     val result = (args.partition { s =>
       G8.Param.pattern.matcher(s).matches
     } match {
       case (params, options) =>
         parser.parse(options, Config("")).map { config =>
-          helper.run(config, params, new File("."))
+          helper.run(config, params, baseDirectory)
         }.getOrElse(Left(""))
       case _ => Left(parser.usage)
     })
@@ -47,6 +47,8 @@ class Giter8 extends xsbti.AppMain {
       0
     })
   }
+
+  def run(args: Array[String]):Int = run(args, new File("."))
 
   val parser = new scopt.OptionParser[Config]("giter8") {
     head("g8", giter8.BuildInfo.version)

--- a/app/src/main/scala/giter8.scala
+++ b/app/src/main/scala/giter8.scala
@@ -48,7 +48,7 @@ class Giter8 extends xsbti.AppMain {
     })
   }
 
-  def run(args: Array[String]):Int = run(args, new File("."))
+  def run(args: Array[String]):Int = run(args, (new File(".")).getAbsoluteFile)
 
   val parser = new scopt.OptionParser[Config]("giter8") {
     head("g8", giter8.BuildInfo.version)


### PR DESCRIPTION
If Giter8.run() is used as a library call, it is impossible to control the directory where the template will be generated: it will always be expanded in a subdirectory of the current directory, as returned by the property "user.dir". However, the calling program may not change its current directory by setting the property: that leads to inconsistencies in the .exists() call on Files, and is generally not supported by the VM, see: http://stackoverflow.com/questions/2275362/java-file-exists-inconsistencies-when-setting-user-dir
This pull request adds a variant to the run() method, where the required output directory can be specified explicitly.