### PR TITLE
Issue #282: Refactoring altered the semantics

### DIFF
--- a/app/src/main/scala/giter8/Giter8.scala
+++ b/app/src/main/scala/giter8/Giter8.scala
@@ -81,7 +81,7 @@ class Giter8 extends xsbti.AppMain {
     } yield res
 
     if (tempdir.exists) FileUtils.forceDelete(tempdir)
-    result
+    result.map(_ => s"Template applied to ${config.output.getOrElse(".")}")
   }
 
   private def getOutputDirectory(output: Option[String]): Try[File] = output match {

--- a/app/src/main/scala/giter8/Giter8.scala
+++ b/app/src/main/scala/giter8/Giter8.scala
@@ -76,7 +76,7 @@ class Giter8 extends xsbti.AppMain {
                                         config.directory,
                                         outputDirectory = out,
                                         parameters,
-                                        interactive = true,
+                                        interactive = parameters.isEmpty,
                                         force       = config.forceOverwrite)
     } yield res
 

--- a/library/src/main/scala/giter8/FileRenderer.scala
+++ b/library/src/main/scala/giter8/FileRenderer.scala
@@ -60,11 +60,7 @@ object FileRenderer {
   private def renderFileImpl(in: File, out: File, parameters: Map[String, String]): Try[Unit] = {
     for {
       templateBody <- Try(FileUtils.readFileToString(in, "UTF-8"))
-      content <- {
-
-        val res = StringRenderer.render(templateBody, parameters)
-        res
-      }
+      content      <- StringRenderer.render(templateBody, parameters)
       res <- Try {
         FileUtils.writeStringToFile(out, content, UTF_8)
         copyFileAttributes(in, out)

--- a/library/src/main/scala/giter8/Giter8Engine.scala
+++ b/library/src/main/scala/giter8/Giter8Engine.scala
@@ -51,21 +51,25 @@ case class Giter8Engine(httpClient: HttpClient = ApacheHttpClient) {
     for {
       templateDirectory <- Try(new File(templateDirectory, templatePath.getOrElse("")))
       template          <- Try(Template(templateDirectory))
-      propertyResolver  <- makePropertyResolver(template.propertyFiles, additionalProperties, interactive)
-      parameters        <- propertyResolver.resolve(Map.empty)
-      packageDir        <- Success(parameters.get("name").map(FormatFunctions.normalize).getOrElse(""))
-      out               <- Try(outputDirectory / packageDir)
-      res               <- TemplateRenderer.render(template.root, template.templateFiles, out, parameters, force)
-      _                 <- TemplateRenderer.copyScaffolds(template.scaffoldsRoot, template.scaffoldsFiles, out / ".g8")
+      propertyResolver <- makePropertyResolver(template.propertyFiles,
+                                               template.properties,
+                                               additionalProperties,
+                                               interactive)
+      parameters <- propertyResolver.resolve(Map.empty)
+      packageDir <- Success(parameters.get("name").map(FormatFunctions.normalize).getOrElse(""))
+      out        <- Try(outputDirectory / packageDir)
+      res        <- TemplateRenderer.render(template.root, template.templateFiles, out, parameters, force)
+      _          <- TemplateRenderer.copyScaffolds(template.scaffoldsRoot, template.scaffoldsFiles, out / ".g8")
     } yield res
 
   private def makePropertyResolver(propertyFiles: Seq[File],
+                                   templateProperties: Set[String],
                                    additionalProperties: Map[String, String],
                                    interactive: Boolean) = Success {
     val resolvers = Seq(FilePropertyResolver(propertyFiles: _*),
                         MavenPropertyResolver(httpClient),
                         StaticPropertyResolver(additionalProperties))
-    if (interactive) PropertyResolverChain(resolvers :+ InteractivePropertyResolver: _*)
+    if (interactive) PropertyResolverChain(resolvers :+ InteractivePropertyResolver(templateProperties): _*)
     else PropertyResolverChain(resolvers: _*)
   }
 }

--- a/library/src/main/scala/giter8/Giter8Engine.scala
+++ b/library/src/main/scala/giter8/Giter8Engine.scala
@@ -47,7 +47,7 @@ case class Giter8Engine(httpClient: HttpClient = ApacheHttpClient) {
                     outputDirectory: File,
                     additionalProperties: Map[String, String],
                     interactive: Boolean = false,
-                    force: Boolean       = false): Try[String] =
+                    force: Boolean       = false): Try[Unit] =
     for {
       templateDirectory <- Try(new File(templateDirectory, templatePath.getOrElse("")))
       template          <- Try(Template(templateDirectory))

--- a/library/src/main/scala/giter8/PropertyResolvers.scala
+++ b/library/src/main/scala/giter8/PropertyResolvers.scala
@@ -134,8 +134,8 @@ object InteractivePropertyResolver extends PropertyResolver {
           val LsCall = """ls\((.*),(.*)\)""".r
           value match {
             case LsCall(group, artifact) =>
-              println(s"$name [Please, enter the ${group.trim}#${artifact.trim} version]: ")
-            case _ => println(s"$name [$value]: ")
+              print(s"$name [Please, enter the ${group.trim}#${artifact.trim} version]: ")
+            case _ => print(s"$name [$value]: ")
           }
           Console.flush() // Gotta flush for Windows console!
           Option(Console.readLine()) match {

--- a/library/src/main/scala/giter8/TemplateRenderer.scala
+++ b/library/src/main/scala/giter8/TemplateRenderer.scala
@@ -30,12 +30,14 @@ object TemplateRenderer {
              templateFiles: Seq[File],
              outputDirectory: File,
              parameters: Map[String, String],
-             force: Boolean): Try[String] = {
+             force: Boolean): Try[Unit] = {
 
-    templateFiles.foreach { file =>
-      writeTemplateFile(templateRoot, file, parameters, outputDirectory, force)
+    for (file <- templateFiles) {
+      val result = writeTemplateFile(templateRoot, file, parameters, outputDirectory, force)
+      if (result.isFailure) return result
     }
-    Success(s"Template applied in ${outputDirectory.toString}")
+
+    Success(())
   }
 
   def copyScaffolds(scaffoldsRoot: Option[File], scaffoldsFiles: Seq[File], outputDirectory: File): Try[Unit] = Try {

--- a/library/src/main/scala/giter8/TemplateRenderer.scala
+++ b/library/src/main/scala/giter8/TemplateRenderer.scala
@@ -25,6 +25,7 @@ import org.stringtemplate.v4.compiler.STException
 import scala.util.{Failure, Success, Try}
 
 object TemplateRenderer {
+  import Util.relativePath
 
   def render(templateRoot: File,
              templateFiles: Seq[File],
@@ -78,11 +79,5 @@ object TemplateRenderer {
     }
 
     new File(toPath, StringRenderer.render(FormatFunctions.formatize(relative), params).get)
-  }
-
-  private def relativePath(from: File, to: File): String = {
-    val fromUri = from.toURI
-    val toUti   = to.toURI
-    fromUri.relativize(toUti).getPath
   }
 }

--- a/library/src/main/scala/giter8/Util.scala
+++ b/library/src/main/scala/giter8/Util.scala
@@ -17,6 +17,8 @@
 
 package giter8
 
+import java.io.File
+
 object Util {
 
   def parseArguments(args: Seq[String]): Map[String, String] = {
@@ -25,5 +27,11 @@ object Util {
       case param(k, v) => k -> v
     }
     pairs.toMap
+  }
+
+  def relativePath(from: File, to: File): String = {
+    val fromUri = from.toURI
+    val toUti   = to.toURI
+    fromUri.relativize(toUti).getPath
   }
 }

--- a/library/src/test/scala/giter8/StringRendererTest.scala
+++ b/library/src/test/scala/giter8/StringRendererTest.scala
@@ -115,7 +115,7 @@ class StringRendererTest extends FlatSpec with Matchers with TryValues {
     "$foo;format=\"snake-case\"$" withParameters Map("foo" -> "with-dash") shouldBe formattedAs("with_dash")
   }
 
-  it can "package" in {
+  it can "make package name" in {
     "$foo;format=\"packaged\"$" withParameters Map("foo" -> "com.example") shouldBe formattedAs("com/example")
 
     "$foo;format=\"package-dir\"$" withParameters Map("foo" -> "com.example.foo") shouldBe
@@ -152,7 +152,7 @@ object StringRendererTest {
             matches                  = actual == right,
             rawNegatedFailureMessage = s""""${left.body}" was formatted as "$right"""",
             rawFailureMessage = s""""${left.body}" should be formatted as "$right" with """ +
-                s"""${formatParameters(left.parameters)}, but got "$actual".""".stripMargin
+              s"""${formatParameters(left.parameters)}, but got "$actual".""".stripMargin
           )
         case Failure(e) =>
           MatchResult(

--- a/library/src/test/scala/giter8/TemplateTest.scala
+++ b/library/src/test/scala/giter8/TemplateTest.scala
@@ -54,4 +54,36 @@ class TemplateTest extends FlatSpec with Matchers with TestFileHelpers {
       temp / "template" / "foo.txt"
     )
   }
+
+  it should "find all properties in all template files" in tempDirectory { temp =>
+    "$foo$" >> (temp / "template" / "simple.txt")
+
+    "$bar;format=\"Camel\"$" >> (temp / "template" / "with_format.txt")
+    "$baz;format=\"Foo,bar\"$" >> (temp / "template" / "with_two_formats.txt")
+
+    "$one$ some text $two$" >> (temp / "template" / "two_params.txt")
+    "$three;format=\"foo\"$ some text $four;format=\"foo\"$" >> (temp / "template" / "two_params_with_format.txt")
+
+    "$файл_with_AllWordChars$" >> (temp / "template" / "unicode.txt")
+
+    val template = Template(temp / "template")
+    template.properties should contain theSameElementsAs Seq(
+      "foo",
+      "one",
+      "two",
+      "three",
+      "four",
+      "bar",
+      "baz",
+      "файл_with_AllWordChars"
+    )
+  }
+
+  it should "collect properties without duplicates" in tempDirectory { temp =>
+    "$foo$ some text $foo$" >> (temp / "template" / "simple.txt")
+
+    val template = Template(temp / "template")
+    template.properties should contain theSameElementsAs Seq("foo")
+  }
+
 }

--- a/plugin/src/main/scala/giter8/Giter8Plugin.scala
+++ b/plugin/src/main/scala/giter8/Giter8Plugin.scala
@@ -112,7 +112,7 @@ object Giter8Plugin extends sbt.AutoPlugin {
     g8Test := scriptedTask.evaluated
   )
 
-  private def applyTemplate(out: File, props: Map[String, String], template: Template): Try[String] = {
+  private def applyTemplate(out: File, props: Map[String, String], template: Template): Try[Unit] = {
     IO.delete(out)
     for {
       packageDir <- Success(props.get("name").map(FormatFunctions.normalize).getOrElse("."))

--- a/scaffold/src/main/scala/giter8/ScaffoldPlugin.scala
+++ b/scaffold/src/main/scala/giter8/ScaffoldPlugin.scala
@@ -54,7 +54,8 @@ object ScaffoldPlugin extends sbt.AutoPlugin {
     val folder       = g8ScaffoldTemplatesDirectory.value
     val log          = streams.value.log
     val giter8Engine = Giter8Engine(ApacheHttpClient)
-    giter8Engine.applyTemplate(folder / name, None, baseDirectory.value, Util.parseArguments(args), interactive = true) match {
+    val arguments    = Util.parseArguments(args)
+    giter8Engine.applyTemplate(folder / name, None, baseDirectory.value, arguments, interactive = arguments.isEmpty) match {
       case Success(s) => log.info(s"Template '$name' applied")
       case Failure(e) => log.error(e.getMessage)
     }


### PR DESCRIPTION
Fixes regressions after refactoring (resolves #282):

1. The non-interactive behaviour turned into interactive: the value passed on the command line is used as a default, but it still stops.
1. Blinking cursor appears on a separate line.
1. Expansions of unknown parameters no longer lead to an error message, but appear to succeed, except the generated directory is empty.