### PR TITLE
symlinks support

### DIFF
--- a/library/src/main/scala/giter8/Git.scala
+++ b/library/src/main/scala/giter8/Git.scala
@@ -77,7 +77,7 @@ class Git(gitInteractor: GitInteractor) {
   }
 
   // Protected for testing: see GitTest.scala
-  protected def cleanDir(dir: File): Unit = dir.listFiles().foreach(_.delete())
+  protected def cleanDir(dir: File): Unit = FileUtils.cleanDirectory(dir)
 
   // Protected for testing: see GitTest.scala
   protected def copy(from: File, to: File): Try[Unit] = Try {

--- a/library/src/main/scala/giter8/GitInteractor.scala
+++ b/library/src/main/scala/giter8/GitInteractor.scala
@@ -43,14 +43,18 @@ object GitInteractor {
 object JGitInteractor extends GitInteractor {
   CredentialsProvider.setDefault(ConsoleCredentialsProvider)
 
-  override def cloneRepository(url: String, dest: File): Try[Unit] = Try {
-    JGit
-      .cloneRepository()
-      .setURI(url)
-      .setDirectory(dest)
-      .setCredentialsProvider(ConsoleCredentialsProvider)
-      .call()
-      .close()
+  override def cloneRepository(url: String, dest: File): Try[Unit] = {
+    Try(
+      JGit
+        .cloneRepository()
+        .setURI(url)
+        .setDirectory(dest)
+        .setCredentialsProvider(ConsoleCredentialsProvider)
+        .call()
+        .close()
+    ).recoverWith{
+      case e: TransportException => Failure(TransportError(e.getMessage))
+    }
   }
 
   override def getRemoteBranches(url: String): Try[Seq[String]] = {

--- a/library/src/main/scala/giter8/TemplateRenderer.scala
+++ b/library/src/main/scala/giter8/TemplateRenderer.scala
@@ -25,7 +25,7 @@ import org.stringtemplate.v4.compiler.STException
 import scala.util.{Failure, Success, Try}
 
 object TemplateRenderer {
-  import Util.relativePath
+  import Util._
 
   def render(templateRoot: File,
              templateFiles: Seq[File],
@@ -33,7 +33,7 @@ object TemplateRenderer {
              parameters: Map[String, String],
              force: Boolean): Try[Unit] = {
 
-    for (file <- templateFiles) {
+    for (file <- listFilesAndDirsWithSymbolicLinks(templateRoot, templateFiles)) {
       val result = writeTemplateFile(templateRoot, file, parameters, outputDirectory, force)
       if (result.isFailure) return result
     }

--- a/library/src/main/scala/giter8/TestFileHelpers.scala
+++ b/library/src/main/scala/giter8/TestFileHelpers.scala
@@ -18,6 +18,7 @@ package giter8
  */
 
 import java.io.{File, PrintWriter}
+import java.nio.file.Files
 
 import org.apache.commons.io.FileUtils
 
@@ -38,6 +39,10 @@ trait TestFileHelpers {
   def touch(file: File): Unit = if (!file.exists) {
     file.getParentFile.mkdirs()
     file.createNewFile()
+  }
+
+  def symLink(link: File, target: File): Unit = if(!link.exists()) {
+    Files.createSymbolicLink(link.toPath, target.toPath)
   }
 
   implicit class WriteableString(s: String) {

--- a/library/src/main/scala/giter8/TestFileHelpers.scala
+++ b/library/src/main/scala/giter8/TestFileHelpers.scala
@@ -42,6 +42,7 @@ trait TestFileHelpers {
   }
 
   def symLink(link: File, target: File): Unit = if(!link.exists()) {
+    if (target.isFile && !link.getParentFile.exists()) link.getParentFile.mkdirs()
     SymlinkUtils.createSymbolicLink(link, target)
   }
 

--- a/library/src/main/scala/giter8/TestFileHelpers.scala
+++ b/library/src/main/scala/giter8/TestFileHelpers.scala
@@ -18,9 +18,9 @@ package giter8
  */
 
 import java.io.{File, PrintWriter}
-import java.nio.file.Files
 
 import org.apache.commons.io.FileUtils
+import org.codehaus.plexus.components.io.attributes.SymlinkUtils
 
 trait TestFileHelpers {
   def tempDirectory(code: File => Unit): Unit = {
@@ -42,7 +42,7 @@ trait TestFileHelpers {
   }
 
   def symLink(link: File, target: File): Unit = if(!link.exists()) {
-    Files.createSymbolicLink(link.toPath, target.toPath)
+    SymlinkUtils.createSymbolicLink(link, target)
   }
 
   implicit class WriteableString(s: String) {

--- a/library/src/main/scala/giter8/Util.scala
+++ b/library/src/main/scala/giter8/Util.scala
@@ -18,10 +18,10 @@
 package giter8
 
 import java.io.File
-import java.nio.file.Files
 
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.filefilter.TrueFileFilter
+import org.codehaus.plexus.components.io.attributes.SymlinkUtils
 
 import scala.collection.JavaConverters._
 import scala.util.Try
@@ -58,12 +58,12 @@ object Util {
     else hasSymbolicParent(f.getParentFile, topFolder)
   }
 
-  def isSymbolicLink(file: File): Boolean = Files.isSymbolicLink(file.toPath)
+  def isSymbolicLink(f: File): Boolean = FileUtils.isSymlink(f)
 
   def link(in: File, out: File) = Try {
-    val inTargetPath = Files.readSymbolicLink(in.toPath)
-    val outTarget = new File(out.getParentFile.getAbsolutePath, inTargetPath.toFile.getName)
-    Files.createSymbolicLink(out.toPath, outTarget.toPath)
+    val inTargetPath = SymlinkUtils.readSymbolicLink(in)
+    val outTarget = new File(out.getParentFile.getAbsolutePath, inTargetPath.getName)
+    SymlinkUtils.createSymbolicLink(out, outTarget)
     ()
   }
 }

--- a/library/src/main/scala/giter8/Util.scala
+++ b/library/src/main/scala/giter8/Util.scala
@@ -38,8 +38,8 @@ object Util {
 
   def relativePath(from: File, to: File): String = {
     val fromUri = from.toURI
-    val toUti   = to.toURI
-    fromUri.relativize(toUti).getPath
+    val toUri   = to.toURI
+    fromUri.relativize(toUri).getPath
   }
 
   def listFilesAndDirsWithSymbolicLinks(folder: File): Seq[File] = {

--- a/library/src/test/scala/giter8/FileContentMatchers.scala
+++ b/library/src/test/scala/giter8/FileContentMatchers.scala
@@ -1,6 +1,7 @@
 package giter8
 
 import java.io.File
+import java.nio.file.Files
 
 import org.scalatest.matchers.{MatchResult, Matcher}
 
@@ -15,6 +16,17 @@ trait FileContentMatchers {
         rawFailureMessage =
           s"File ${left.getAbsolutePath} has invalid contents:\n\texpected $contents\n\tactual: $fileContents",
         rawNegatedFailureMessage = s"${left.getAbsolutePath} has contents $contents"
+      )
+    }
+  }
+
+  def beSymbolicLink(): Matcher[File] = new Matcher[File] {
+    override def apply(left: File): MatchResult = {
+      MatchResult(
+        matches = Files.isSymbolicLink(left.toPath),
+        rawFailureMessage =
+          s"File ${left.getAbsolutePath} is not a symbolic link",
+        rawNegatedFailureMessage = s"${left.getAbsolutePath} is a symbolic link"
       )
     }
   }

--- a/library/src/test/scala/giter8/FileContentMatchers.scala
+++ b/library/src/test/scala/giter8/FileContentMatchers.scala
@@ -1,7 +1,6 @@
 package giter8
 
 import java.io.File
-import java.nio.file.Files
 
 import org.scalatest.matchers.{MatchResult, Matcher}
 
@@ -23,7 +22,7 @@ trait FileContentMatchers {
   def beSymbolicLink(): Matcher[File] = new Matcher[File] {
     override def apply(left: File): MatchResult = {
       MatchResult(
-        matches = Files.isSymbolicLink(left.toPath),
+        matches = Util.isSymbolicLink(left),
         rawFailureMessage =
           s"File ${left.getAbsolutePath} is not a symbolic link",
         rawNegatedFailureMessage = s"${left.getAbsolutePath} is a symbolic link"

--- a/library/src/test/scala/giter8/FileRendererTest.scala
+++ b/library/src/test/scala/giter8/FileRendererTest.scala
@@ -67,15 +67,15 @@ class FileRendererTest extends FlatSpec with Matchers with TestFileHelpers with 
   }
 
   it should "handle symbolic links" in tempDirectory { temp =>
-    "$name$" >> (temp / "in")
-    symLink(temp / "in_link", temp / "in")
+    "$name$" >> (temp / "template" / "in")
+    symLink(temp / "template" / "in_link", temp / "template" / "in")
 
-    renderFile(temp / "in", temp / "out", Map("name" -> "foo")).success
-    renderFile(temp / "in_link", temp / "out_link", Map("name" -> "foo")).success
+    renderFile(temp / "template" / "in", temp / "output" / "in", Map("name" -> "foo")).success
+    renderFile(temp / "template" / "in_link", temp / "output" / "in_link", Map("name" -> "foo")).success
 
-    temp / "out" should exist
-    temp / "out" should haveContents("foo")
-    temp / "in_link" should beSymbolicLink()
-    temp / "out_link" should beSymbolicLink()
+    temp / "output" / "in" should exist
+    temp / "output" / "in" should haveContents("foo")
+    temp / "output" / "in" shouldNot beSymbolicLink()
+    temp / "output" / "in_link" should beSymbolicLink()
   }
 }

--- a/library/src/test/scala/giter8/FileRendererTest.scala
+++ b/library/src/test/scala/giter8/FileRendererTest.scala
@@ -65,4 +65,17 @@ class FileRendererTest extends FlatSpec with Matchers with TestFileHelpers with 
       actual.get.isSymbolicLink should equal(expected.get.isSymbolicLink)
     } else expected.isDefined shouldBe false
   }
+
+  it should "handle symbolic links" in tempDirectory { temp =>
+    "$name$" >> (temp / "in")
+    symLink(temp / "in_link", temp / "in")
+
+    renderFile(temp / "in", temp / "out", Map("name" -> "foo")).success
+    renderFile(temp / "in_link", temp / "out_link", Map("name" -> "foo")).success
+
+    temp / "out" should exist
+    temp / "out" should haveContents("foo")
+    temp / "in_link" should beSymbolicLink()
+    temp / "out_link" should beSymbolicLink()
+  }
 }

--- a/library/src/test/scala/giter8/IntegrationTest.scala
+++ b/library/src/test/scala/giter8/IntegrationTest.scala
@@ -79,6 +79,21 @@ class IntegrationTest extends FlatSpec with IntegrationTestHelpers with Matchers
       checkGeneratedProject(template, expected, actual)
   }
 
+  it should "create symbolic links from template" in testCase {
+    case (template, expected, actual) =>
+      touch(template / "A" / "foo.txt")
+      symLink(template / "B", template / "A")
+      "I am foo.txt" >> (template / "foo.txt")
+      symLink(template / "bar.txt", template / "foo.txt")
+
+      touch(expected / "A" / "foo.txt")
+      symLink(expected / "B", expected / "A")
+      "I am foo.txt" >> (expected / "foo.txt")
+      symLink(expected / "bar.txt", expected / "foo.txt")
+
+      checkGeneratedProject(template, expected, actual)
+  }
+
   it should "read default.properties from template root" in testCase {
     case (template, expected, actual) =>
       "foo = bar" >> (template / "src" / "main" / "g8" / "default.properties")

--- a/library/src/test/scala/giter8/IntegrationTest.scala
+++ b/library/src/test/scala/giter8/IntegrationTest.scala
@@ -79,12 +79,27 @@ class IntegrationTest extends FlatSpec with IntegrationTestHelpers with Matchers
       checkGeneratedProject(template, expected, actual)
   }
 
-  it should "create symbolic links from template" in testCase {
+  it should "create symbolic links from template root" in testCase {
     case (template, expected, actual) =>
       touch(template / "A" / "foo.txt")
       symLink(template / "B", template / "A")
       "I am foo.txt" >> (template / "foo.txt")
       symLink(template / "bar.txt", template / "foo.txt")
+
+      touch(expected / "A" / "foo.txt")
+      symLink(expected / "B", expected / "A")
+      "I am foo.txt" >> (expected / "foo.txt")
+      symLink(expected / "bar.txt", expected / "foo.txt")
+
+      checkGeneratedProject(template, expected, actual)
+  }
+
+  it should "create symbolic links from src template" in testCase {
+    case (template, expected, actual) =>
+      touch(template / "src" / "main" / "g8" / "A" / "foo.txt")
+      symLink(template / "src" / "main" / "g8" / "B", template / "src" / "main" / "g8" / "A")
+      "I am foo.txt" >> (template / "src" / "main" / "g8" / "foo.txt")
+      symLink(template / "src" / "main" / "g8" / "bar.txt", template / "src" / "main" / "g8" / "foo.txt")
 
       touch(expected / "A" / "foo.txt")
       symLink(expected / "B", expected / "A")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,4 @@
-import sbt.{ExclusionRule, _}
+import sbt._
 
 object Dependencies {
   val scalasti  = "org.clapper" %% "scalasti" % "2.1.2"
@@ -10,14 +10,10 @@ object Dependencies {
     ExclusionRule("junit", "junit")
   )
   // Picking jgit used by sbt-git
-  // https://github.com/eclipse/jgit/blob/v4.5.0.201609210915-r/pom.xml
-  // This uses httpclient 4.3.6
-  // http://hc.apache.org/httpcomponents-client-4.3.x/
-  val jgit             = "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "4.5.0.201609210915-r" excludeAll (
-    ExclusionRule("javax.jms", "jms"),
-    ExclusionRule("com.sun.jdmk", "jmxtools"),
-    ExclusionRule("com.sun.jmx", "jmxri")
-  )
+  // https://github.com/eclipse/jgit/blob/v3.7.0.201502260915-r/pom.xml
+  // This uses httpclient 4.1
+  // http://hc.apache.org/httpcomponents-client-4.2.x/
+  val jgit             = "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.7.0.201502260915-r"
   val scopt            = "com.github.scopt" %% "scopt" % "3.5.0"
   val scalacheck       = "org.scalacheck" %% "scalacheck" % "1.13.4"
   val scalatest        = "org.scalatest" %% "scalatest" % "3.0.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,4 @@
-import sbt._
+import sbt.{ExclusionRule, _}
 
 object Dependencies {
   val scalasti  = "org.clapper" %% "scalasti" % "2.1.2"
@@ -10,10 +10,14 @@ object Dependencies {
     ExclusionRule("junit", "junit")
   )
   // Picking jgit used by sbt-git
-  // https://github.com/eclipse/jgit/blob/v3.7.0.201502260915-r/pom.xml
-  // This uses httpclient 4.1
-  // http://hc.apache.org/httpcomponents-client-4.2.x/
-  val jgit             = "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.7.0.201502260915-r"
+  // https://github.com/eclipse/jgit/blob/v4.5.0.201609210915-r/pom.xml
+  // This uses httpclient 4.3.6
+  // http://hc.apache.org/httpcomponents-client-4.3.x/
+  val jgit             = "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "4.5.0.201609210915-r" excludeAll (
+    ExclusionRule("javax.jms", "jms"),
+    ExclusionRule("com.sun.jdmk", "jmxtools"),
+    ExclusionRule("com.sun.jmx", "jmxri")
+  )
   val scopt            = "com.github.scopt" %% "scopt" % "3.5.0"
   val scalacheck       = "org.scalacheck" %% "scalacheck" % "1.13.4"
   val scalatest        = "org.scalatest" %% "scalatest" % "3.0.1"


### PR DESCRIPTION
If the template repo contains symbolic links g8 does not recognise them and the content gets duplicated.

The PR handles this creating symbolic links when detected. Unfortunately this works for local templates only at the moment. To support remote repos as well we should upgrade jgit (symlinks support has been added in a later version https://bugs.eclipse.org/bugs/show_bug.cgi?id=354367) but I am not sure we can do this. It would be awesome to have this feature. Any idea?