### PR TITLE
update giter8 repository for conscript

### DIFF
--- a/docs/05.md
+++ b/docs/05.md
@@ -35,7 +35,7 @@ You can either delete existing version of giter8, or change `PATH` variable such
 
 #### To get back to normal version:
 
-From a shell session run `cs foundweekends/g8`.
+From a shell session run `cs foundweekends/giter8`.
 
 [official page]: https://github.com/foundweekends/conscript
 [conscript]: http://www.foundweekends.org/conscript/


### PR DESCRIPTION
The conscript repository provided for giter8:

  cs foundweekends/g8

fails with a "Github repository not found" error.

Updated the repository path to match that of the giter8 repository.