### PR TITLE
0.8.x configurable g8token

### DIFF
--- a/library/src/main/scala/giter8/FileRenderer.scala
+++ b/library/src/main/scala/giter8/FileRenderer.scala
@@ -75,8 +75,23 @@ object FileRenderer {
     }
   }
 
+  val verbatimKey = "verbatim"
+
+  private[giter8] def verbatimFunction(propResolver: PropertyResolver): File => Boolean = {
+    val verbatimValue: Option[String] = propResolver.resolve(Map.empty) match {
+      case Failure(_) => None
+      case Success(map) => map.get(verbatimKey)
+    }
+    { file: File =>
+      verbatim(file, verbatimValue)
+    }
+  }
+
   private[giter8] def verbatim(file: File, parameters: Map[String, String]): Boolean =
-    parameters.get("verbatim") match {
+    verbatim(file, parameters.get(verbatimKey))
+
+  private[giter8] def verbatim(file: File, verbatimValue: Option[String]): Boolean =
+    verbatimValue match {
       case None => false
       case Some(patterns) =>
         patterns.split(' ').exists { pattern =>

--- a/library/src/main/scala/giter8/Template.scala
+++ b/library/src/main/scala/giter8/Template.scala
@@ -31,7 +31,7 @@ class Template private (baseDirectory: File, val root: File, val scaffoldsRoot: 
 
   private val log = Logger.getLogger("giter8.Template")
 
-  private val PropertyMatcher = """\$([^\;\$]*)(;format=\"[^\$\"]*\")?\$""".r
+  private val PropertyMatcher = StringRenderer.options.propertyMatcher.r
 
   private lazy val metaDir     = baseDirectory / "project"
   private lazy val gitFiles    = files(baseDirectory / ".git").toSet
@@ -51,7 +51,13 @@ class Template private (baseDirectory: File, val root: File, val scaffoldsRoot: 
 
   val scaffoldsFiles: Seq[File] = scaffoldsRoot.map(files).getOrElse(Seq.empty)
 
-  lazy val (propertyFiles, templateFiles) = files(root)
+  lazy val propertyFiles = possiblePropertyFiles.toList.filter(f => f.exists())
+
+  lazy val isVerbatim = FileRenderer.verbatimFunction(new FilePropertyResolver(propertyFiles:_*))
+
+  //lazy val (propertyFiles, templateFiles) =
+  lazy val (_, templateFiles) = files(root)
+    .filterNot(isVerbatim)
     .filterNot(isIgnored)
     .filterNot(gitFiles)
     .filterNot(pluginFiles)


### PR DESCRIPTION
Using the $ as a replacement token is not really an option for us here (the amount of dollars we have to escape is humongous, either in Scala or JS), so i decided to introduce support for a configurable token, as an alternative to $.
I did this using a system property (g8token), as it is the quickest way to pass something through SBT without a new setting key, but especially the least intrusive change to giter8 lib. This way i don't need to heavily refactor the way lib is configured, and i can have 'static' code (in objects) to use it.

To use this, i just pass to sbt g8
-Dg8token=§ 
and the alternative char is used
We are using char § as the token. I never saw it being used before, and actually looks like a dollar, so its perfect.

Also i fixed a conceptual flaw: properties were being scanned in ALL files, even in files that were later matched to verbatim and ignored for replacement. We should not scan properties in files we will never replace anything (the verbatim extensions). So now i read the default.properties before scanning for properties in template files, and i filter out the verbatim.

I think this patch might be a valuable addition to giter8

As the default char is $, and this functionality is triggered via system property, all current tests are passing.
I didn't add any tests for this (but makes sense to have at least one), nor i added anything to documentation.

