### PR TITLE
Add some description after apply template

### DIFF
--- a/library/src/main/scala/giter8/Giter8Engine.scala
+++ b/library/src/main/scala/giter8/Giter8Engine.scala
@@ -59,6 +59,7 @@ case class Giter8Engine(httpClient: HttpClient = ApacheHttpClient) {
       packageDir <- Success(parameters.get("name").map(FormatFunctions.normalize).getOrElse(""))
       out        <- Try(outputDirectory / packageDir)
       res        <- TemplateRenderer.render(template.root, template.templateFiles, out, parameters, force)
+      _          <- TemplateRenderer.showReadMe(out)
       _          <- TemplateRenderer.copyScaffolds(template.scaffoldsRoot, template.scaffoldsFiles, out / ".g8")
     } yield res
 

--- a/library/src/main/scala/giter8/TemplateRenderer.scala
+++ b/library/src/main/scala/giter8/TemplateRenderer.scala
@@ -22,9 +22,11 @@ import java.io.File
 import org.apache.commons.io.FileUtils
 import org.stringtemplate.v4.compiler.STException
 
+import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
 object TemplateRenderer {
+
   import Util.relativePath
 
   def render(templateRoot: File,
@@ -48,6 +50,18 @@ object TemplateRenderer {
         val out  = new File(outputDirectory, name)
         FileUtils.copyFile(file, out)
       }
+    }
+  }
+
+  def showReadMe(path: File) = {
+    if (!path.exists()) Success(())
+
+    val readmeG8 = new File(path, "README.g8")
+    Try {
+      println()
+      Source.fromFile(readmeG8, "UTF-8").getLines.foreach(println)
+      println()
+      readmeG8.delete()
     }
   }
 

--- a/library/src/main/scala/giter8/TemplateRenderer.scala
+++ b/library/src/main/scala/giter8/TemplateRenderer.scala
@@ -53,15 +53,17 @@ object TemplateRenderer {
     }
   }
 
-  def showReadMe(path: File) = {
-    if (!path.exists()) Success(())
-
+  def showReadMe(path: File): Try[Unit] = {
     val readmeG8 = new File(path, "README.g8")
-    Try {
+
+    if (!readmeG8.exists()) Success(())
+    else Try[Unit] {
       println()
       Source.fromFile(readmeG8, "UTF-8").getLines.foreach(println)
       println()
       readmeG8.delete()
+    } recover {
+      case _ => ()
     }
   }
 


### PR DESCRIPTION
Normally after applying a template some tips are good to show the user how to use just applied template.

This PR tries to solve this showing the content of `src/main/g8/README.g8` after it applies the template, if the file exists.

