### PR TITLE
Apply the verbatim pattern on the full path of the file instead of ju…

### DIFF
--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -164,7 +164,7 @@ object G8 {
       globMatch(file, s.split(' ').toSeq)
     } getOrElse { false }
   private def globMatch(file: File, patterns: Seq[String]): Boolean =
-    patterns exists { globRegex(_).findFirstIn(file.getName).isDefined }
+    patterns exists { globRegex(_).findFirstIn(file.getPath).isDefined }
   private def globRegex(pattern: String) =
     "^%s$"
       .format(pattern flatMap {

--- a/library/src/test/scala/giter8/VerbatimTest.scala
+++ b/library/src/test/scala/giter8/VerbatimTest.scala
@@ -1,0 +1,23 @@
+package giter8
+
+import java.io.File
+
+import org.scalatest.{FlatSpec, Matchers}
+
+
+class VerbatimTest extends FlatSpec with Matchers {
+
+  "G8" should "ignore file based on extension" in {
+    G8.verbatim(new File("/myProject/public/fr/index.html"), Map("verbatim" -> "*.html")) shouldBe true
+  }
+
+  it should "ignore file with wildcard referring a partial path" in {
+    G8.verbatim(new File("/myProject/public/fr/index.html"), Map("verbatim" -> "*/public/*")) shouldBe true
+    G8.verbatim(new File("/myProject/public/fr/index.html"), Map("verbatim" -> "/myProject/*.html")) shouldBe true
+  }
+
+  it should "not ignore file with no wildcard char" in {
+    G8.verbatim(new File("/myProject/public/fr/index.html"), Map("verbatim" -> "myProject")) shouldBe false
+  }
+
+}


### PR DESCRIPTION
Building a template for a website, I would like to :

- Process the *.scala.html but not the *.html
- Ignore a lot of files in my public folder with lot of file extensions (*.svg *.eot *.otf *.ttf *.woff, ....)

To simplify the verbatim, I propose to apply the pattern on the full path instead of the file name.