### PR TITLE
Fixed .gitignore support, added support for rule precedence.

### DIFF
--- a/library/src/test/scala/giter8/IntegrationTest.scala
+++ b/library/src/test/scala/giter8/IntegrationTest.scala
@@ -145,6 +145,43 @@ class IntegrationTest extends FlatSpec with IntegrationTestHelpers with Matchers
       checkGeneratedProject(template, expected, actual)
   }
 
+  it should "allow .g8ignore to take precedence over .gitignore" in testCase {
+    case (template, expected, actual) =>
+      "*"           >> (template / "src" / "main" / "g8" / ".gitignore")
+      "*"           >> (expected / ".gitignore")
+      "!.gitignore" >> (template / ".g8ignore")
+      checkGeneratedProject(template, expected, actual)
+  }
+
+  it should "not ignore default files if .g8ignore is present" in testCase {
+    case (template, expected, actual) =>
+
+      val fileList = Seq(
+        "giter8.sbt", "g8.sbt", "activator.properties", "template.properties", "test", "g8.test", "giter8.test"
+      )
+
+      touch(template / ".g8ignore")
+      touch(template / "target" / "test")
+      touch(template / ".git" / "foo")
+
+      fileList.foreach {
+        file =>
+          touch(template / file)
+          touch(template / "project" / file)
+      }
+
+      touch(expected / "target" / "test")
+      touch(expected / ".git" / "foo")
+
+      fileList.foreach {
+        file =>
+          touch(expected / file)
+          touch(expected / "project" / file)
+      }
+
+      checkGeneratedProject(template, expected, actual)
+  }
+
   private def testCase(test: (File, File, File) => Unit): Unit = {
     tempDirectory { tmp =>
       val templateDir = mkdir(tmp / "template")

--- a/library/src/test/scala/giter8/JGitIgnoreTest.scala
+++ b/library/src/test/scala/giter8/JGitIgnoreTest.scala
@@ -1,13 +1,19 @@
 package giter8
 
 import java.io.ByteArrayInputStream
+import java.net.URI
 
 import org.scalatest.{FlatSpec, Matchers}
 
+import scala.language.implicitConversions
+
 class JGitIgnoreTest extends FlatSpec with Matchers {
+
+  implicit def toURI(s: String): URI = new URI(s)
+
   "JGitIgnore" can "be created from Seq of string patterns" in {
     val patterns = Seq(".test")
-    JGitIgnore(patterns).getPatterns should contain theSameElementsAs patterns
+    JGitIgnore(patterns: _*).getPatterns should contain theSameElementsAs patterns
   }
 
   it can "be created from InputStream" in {
@@ -17,20 +23,39 @@ class JGitIgnoreTest extends FlatSpec with Matchers {
   }
 
   it should "check if file is ignored" in {
-    val ignore = JGitIgnore(Seq("iAmIgnored"))
-    ignore.isIgnored("notIgnored") shouldBe false
+    val ignore = JGitIgnore("iAmIgnored")
+    ignore.isIgnored("iAmNotIgnored") shouldBe false
     ignore.isIgnored("iAmIgnored") shouldBe true
   }
 
   it should "support wildcards" in {
-    val ignore = JGitIgnore(Seq("*.test"))
+    val ignore = JGitIgnore("*.test")
     ignore.isIgnored("foo.test") shouldBe true
     ignore.isIgnored("bar.test") shouldBe true
   }
 
   it should "support nested directories" in {
-    val ignore = JGitIgnore(Seq("*.test"))
+    val ignore = JGitIgnore("*.test")
     ignore.isIgnored("foo/foo.test") shouldBe true
     ignore.isIgnored("bar/bar.test") shouldBe true
+  }
+
+  it should "support negation" in {
+    val ignore = JGitIgnore("*", "!foo")
+    ignore.isIgnored("foo") shouldBe false
+    ignore.isIgnored("bar") shouldBe true
+  }
+
+  it should "support precedence" in {
+    val ignore = JGitIgnore("!foo", "*")
+    ignore.isIgnored("foo") shouldBe true
+    ignore.isIgnored("bar") shouldBe true
+  }
+
+  it should "support relativised files" in {
+    val ignore = JGitIgnore("foo/")
+    ignore.isIgnored("foo/bar") shouldBe true
+    ignore.isIgnored("foo/bar", isDir = false, Some("foo")) shouldBe false
+    ignore.isIgnored("foo/bar", isDir = true, Some("foo")) shouldBe false
   }
 }


### PR DESCRIPTION
Included support for a .g8ignore file at project root.

## Issues addressed

- #329 - I believe this is to do with the ignore rules being applied to the absolute path of the file, which causes odd bugs on different OSes / setups. I have been able to reproduce the problem locally and demonstrate that it's fixed on this branch.
- #337 - I think that this problem is the same as the one above, however, I cannot even reproduce the error locally with v0.9.0, so...
- #221 - This is fixed by default because of changes to the files which are skipped. The `.g8ignore` file feature would also allow issues like this to be fixed with configuration.

## `.g8ignore`
As opposed having a set list of files which are omitted, I've added support for these ignores to be customised in the same way as a `.gitignore` file which people are familiar with. This file should be placed in the root directory of the project.

When the file doesn't exist there is a default list of files which are ignored. This list is the same as the previous ignore list, however, it allows a `test` directory in the output. (It will still ignore a `test` file at the same location)

Happy to write up some documentation if you accept the PR.