### PR TITLE
Fixed wrong giter8 usage example

### DIFF
--- a/app/src/main/scala/giter8.scala
+++ b/app/src/main/scala/giter8.scala
@@ -65,7 +65,7 @@ class Giter8 extends xsbti.AppMain {
 
   def run(args: Array[String]):Int = run(args, new File(".").getAbsoluteFile)
 
-  val parser: OptionParser[Config] = new scopt.OptionParser[Config]("giter8") {
+  val parser: OptionParser[Config] = new scopt.OptionParser[Config]("g8") {
 
     head("g8", giter8.BuildInfo.version)
 


### PR DESCRIPTION
When typing just `g8` with no arguments, following help messages are shown.

```bash
$ g8
Error: Missing argument <template>
g8 0.10.0
Usage: giter8 [options] <template>

(...)
```

In the `Usage: ` part, it says use `giter8` command but in fact, `g8` is the right command. Thus I fixed `programName` passed to `scopt.OptionParser` since it is used when printing usage part.