### PR TITLE
Support capture of multiline template parameters from command line

### DIFF
--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -216,7 +216,7 @@ object G8 {
   def packageDir(s: String)   = s.replace(".", System.getProperty("file.separator"))
   def addRandomId(s: String)  = s + "-" + new java.math.BigInteger(256, new java.security.SecureRandom).toString(32)
 
-  val Param = """^--(\S+)=(.+)$""".r
+  val Param = """(?s)^--(\S+)=(.+)$""".r
   implicit class RichFile(file: File) {
     def /(child: String): File = new File(file, child)
     def /(path: Path): File    = (file /: path.paths) { _ / _ }


### PR DESCRIPTION
Currently, giter8 won't recognize template parameter values that split over multiple lines. 

I traced the reason to this regex, which uses Scala's default single-line match behavior. The `(?s)` flag to java.regex.Pattern enables the `.` character to match a `\n` character and hence work multiline.

```
scala> val multilineParamString = """--myparam=foo
     | bar"""
multilineParamString: String =
--myparam=foo
bar

scala> val regexCurrent = """^--(\S+)=(.+)$""".r
regexCurrent: scala.util.matching.Regex = ^--(\S+)=(.+)$

scala> regexCurrent.pattern.matcher(multilineParamString).matches
res13: Boolean = false

scala> val regexMultiline = """(?s)^--(\S+)=(.+)$""".r
regexMultiline: scala.util.matching.Regex = (?s)^--(\S+)=(.+)$

scala> regexMultiline.pattern.matcher(multilineParamString).matches
res14: Boolean = true
```