### PR TITLE
Supporting multiple formats on file and directory names

### DIFF
--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -203,7 +203,7 @@ object G8 {
         throw t
     }
 
-  private def formatize(s: String) = s.replaceAll("""\$(\w+)__(\w+)\$""", """\$$1;format="$2"\$""")
+  private def formatize(s: String) = s.replaceAll("""\$(\w+)__([\w,]+)\$""", """\$$1;format="$2"\$""")
 
   def decapitalize(s: String) = if (s.isEmpty) s else s(0).toLower + s.substring(1)
   def startCase(s: String)    = s.toLowerCase.split(" ").map(_.capitalize).mkString(" ")

--- a/library/src/test/scala/giter8/IntegrationTest.scala
+++ b/library/src/test/scala/giter8/IntegrationTest.scala
@@ -201,6 +201,16 @@ class IntegrationTest extends FlatSpec with IntegrationTestHelpers with Matchers
       checkGeneratedProject(template, expected, actual)
   }
 
+  it should "apply multiple filters to files and directories" in testCase {
+    case (template, expected, actual) =>
+      """
+        | test = Foo Bar
+      """.stripMargin >> (template / "src" / "main" / "g8" / "default.properties")
+      """$test;format="lower,word"$""" >> (template / "src" / "main" / "g8" / """$test__lower,word$""" / """$test__lower,word$""")
+      "foobar" >> (expected / "foobar" / "foobar")
+      checkGeneratedProject(template, expected, actual)
+  }
+
   private def testCase(test: (File, File, File) => Unit): Unit = {
     tempDirectory { tmp =>
       val templateDir = mkdir(tmp / "template")


### PR DESCRIPTION
This addresses #105 by allowing commas to separate multiple chained formatters.