### PR TITLE
fixes how giter8 deals with scripted test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,6 @@ ThisBuild / scmInfo := Some(
 // posterous title needs to be giter8, so both app and root are named giter8
 lazy val root = (project in file("."))
   .enablePlugins(TravisSitePlugin, NoPublish)
-  .disablePlugins(ScriptedPlugin)
   .aggregate(app, lib, scaffold, plugin)
   .settings(
     name := "giter8",
@@ -45,7 +44,7 @@ lazy val root = (project in file("."))
   )
 
 lazy val app = (project in file("app"))
-  .disablePlugins(BintrayPlugin, ScriptedPlugin)
+  .disablePlugins(BintrayPlugin)
   .enablePlugins(ConscriptPlugin, BuildInfoPlugin, SonatypePublish)
   .dependsOn(lib)
   .settings(
@@ -131,7 +130,7 @@ lazy val plugin = (project in file("plugin"))
   )
 
 lazy val lib = (project in file("library"))
-  .disablePlugins(BintrayPlugin, ScriptedPlugin)
+  .disablePlugins(BintrayPlugin)
   .enablePlugins(SonatypePublish)
   .settings(crossSbt)
   .settings(

--- a/plugin/src/main/scala-sbt-1.0/sbt/sbtgiter8/SBTCompat.scala
+++ b/plugin/src/main/scala-sbt-1.0/sbt/sbtgiter8/SBTCompat.scala
@@ -21,6 +21,7 @@ package sbtgiter8
 object SBTCompat extends ScriptedCompat
 
 trait ScriptedCompat {
+  val finalScriptName      = "test.script"
   val scriptedSettings     = sbt.ScriptedPlugin.projectSettings
   val sbtLauncher          = sbt.ScriptedPlugin.autoImport.sbtLauncher
   val sbtTestDirectory     = sbt.ScriptedPlugin.autoImport.sbtTestDirectory
@@ -31,6 +32,6 @@ trait ScriptedCompat {
   val scriptedLaunchOpts   = sbt.ScriptedPlugin.autoImport.scriptedLaunchOpts
   val scriptedRun          = sbt.ScriptedPlugin.autoImport.scriptedRun
   val scriptedSbt          = sbt.ScriptedPlugin.autoImport.scriptedSbt
-  val scriptedTask         = sbt.ScriptedPlugin.scriptedTask
+  val scriptedTask         = sbt.ScriptedPlugin.autoImport.scripted
   val scriptedTests        = sbt.ScriptedPlugin.autoImport.scriptedTests
 }

--- a/plugin/src/sbt-test/giter8/root-layout/build.sbt
+++ b/plugin/src/sbt-test/giter8/root-layout/build.sbt
@@ -1,0 +1,1 @@
+enablePlugins(ScriptedPlugin)

--- a/plugin/src/sbt-test/giter8/root-layout/build.sbt
+++ b/plugin/src/sbt-test/giter8/root-layout/build.sbt
@@ -1,1 +1,0 @@
-enablePlugins(ScriptedPlugin)

--- a/plugin/src/sbt-test/giter8/simple/build.sbt
+++ b/plugin/src/sbt-test/giter8/simple/build.sbt
@@ -1,3 +1,5 @@
+enablePlugins(ScriptedPlugin)
+
 scriptedBufferLog in (Test, g8) := false
 
 TaskKey[Unit]("writeInvalidFile") := {

--- a/plugin/src/sbt-test/giter8/without-name/build.sbt
+++ b/plugin/src/sbt-test/giter8/without-name/build.sbt
@@ -1,3 +1,6 @@
+
+enablePlugins(ScriptedPlugin)
+
 scriptedBufferLog in (Test, g8) := false
 
 val javaVmArgs: List[String] = {


### PR DESCRIPTION
This PR tries to align how tests are executed for giter8 templates and how sbt-scripted is expected to work. 

It also makes it possible to use it with Play application using the default Play layout for projects. 

This was partially done in https://github.com/sbt/sbt/issues/630, but we need to push this further. 

See PR comments for more context.