### PR TITLE
fix the strange character '5' in the dependency path

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,6 +25,6 @@ object Dependencies {
   val scalaXml         = "org.scala-lang.modules" %% "scala-xml" % "1.2.0"
   val parserCombinator = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
   val logback          = "ch.qos.logback" % "logback-classic" % "1.2.3"
-  val coursier         = "io.get-coursier" %% "coursier" % "2.0.0-RC6-５"
+  val coursier         = "io.get-coursier" %% "coursier" % "2.0.0-RC6-5"
   val launcherIntf     = "org.scala-sbt" % "launcher-interface" % "1.1.3"
 }


### PR DESCRIPTION
Hello,

I found that the recently modified coursier dependency has a strange character in its version. This made my sbt compile fail for not able to resolve the dependency.

I think it is an error. Let me know if I'm wrong.

Kind regards