### PR TITLE
Fix pattern syntax exception on windows

### DIFF
--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -205,7 +205,7 @@ object G8 {
         case x => x
       }: _*)
 
-      val splitter = File.separator.replace("\\","\\\\")
+      val splitter = File.separator.replace("\\", "\\\\")
       val ignored = relative
         .split(splitter)
         .map(part => applyTemplate(formatize(part), fileParams))


### PR DESCRIPTION
On Windows 10 we get the following Exception:

```
sbt:bpf-next-demo> g8Scaffold camunda
component [demo-process]: roman
java.util.regex.PatternSyntaxException: Unexpected internal error near index 1
\
at java.util.regex.Pattern.error(Unknown Source)
at java.util.regex.Pattern.compile(Unknown Source)
at java.util.regex.Pattern.<init>(Unknown Source)
at java.util.regex.Pattern.compile(Unknown Source)
at java.lang.String.split(Unknown Source)
at java.lang.String.split(Unknown Source)
at giter8.G8$.expandPath(g8.scala:212)
at giter8.G8$.$anonfun$writeTemplates$1(g8.scala:488)
at scala.collection.immutable.Stream.map(Stream.scala:414)
at giter8.G8$.writeTemplates(g8.scala:486)
at giter8.G8$.$anonfun$applyT$1(g8.scala:347)
at scala.util.Either$RightProjection.flatMap(Either.scala:697)
at giter8.G8$.applyT(g8.scala:330)
at giter8.G8$.fromDirectoryRaw(g8.scala:90)
at giter8.ScaffoldPlugin$.$anonfun$scaffoldTask$3(ScafoldPlugin.scala:53)
at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
at sbt.std.Transform$$anon$3.$anonfun$apply$2(System.scala:46)
at sbt.std.Transform$$anon$4.work(System.scala:67)
at sbt.Execute.$anonfun$submit$2(Execute.scala:269)
```

According to the following answer: https://stackoverflow.com/a/34129096/2750966

I could fix the Problem.