### PR TITLE
Add `--help` command line option

### DIFF
--- a/cli-git/src/main/scala/Runner.scala
+++ b/cli-git/src/main/scala/Runner.scala
@@ -105,6 +105,8 @@ class Runner {
 
     version("version").text("Display version number")
 
+    help("help").text("Show this help and exit")
+
     note("""  --paramname=paramval  Set given parameter value and bypass interaction
       |
       |EXAMPLES


### PR DESCRIPTION
Currently, using `--help` with g8 returns an error message and exits with status code `1`.

Change this to support `--help` with a proper description, exiting with status code 0.