### PR TITLE
Fix split in expandPath

### DIFF
--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -212,9 +212,8 @@ object G8 {
         case x => x
       }: _*)
 
-      val splitter = File.separator.replace("\\", "\\\\")
       val ignored = relative
-        .split(splitter)
+        .split("/")
         .map(part => applyTemplate(formatize(part), fileParams))
         .exists(_.isEmpty)
 

--- a/library/src/test/scala/giter8/SampleTemplatesIntegrationTest.scala
+++ b/library/src/test/scala/giter8/SampleTemplatesIntegrationTest.scala
@@ -13,13 +13,8 @@ class SampleTemplatesIntegrationTest extends AnyFunSuite with IntegrationTestHel
 
   val testCases: Seq[TestCase] = {
     val testCasesDirectory = new File(getClass.getResource("/testcases").getPath)
-    if (Properties.isWin) {
-      // TODO fix and enable tests
-      Nil
-    } else {
-      testCasesDirectory.listFiles map { testCase =>
-        TestCase(testCase.getName, testCase / "template", testCase / "output")
-      }
+    testCasesDirectory.listFiles map { testCase =>
+      TestCase(testCase.getName, testCase / "template", testCase / "output")
     }
   }
 


### PR DESCRIPTION
The `toURI().relativize` returns path with slashes `/`.  
But in the `expandPath` it splits by `File.separator` (`\` on windows).  
That doesn't work on windows, obviously, different characters.

If we use `Files.relativize` instead of URL we get '\\', but then we get these errors:  
`Check that all literal '$' are properly escaped with '\$'`

So the solution is just to split by `/`.

Fixes #465
