### PR TITLE
Adding reverseOrg string formatter

### DIFF
--- a/docs/03/a.md
+++ b/docs/03/a.md
@@ -12,22 +12,22 @@ formatted in upper camel case with:
 
 The formatting options are:
 
-    upper      | uppercase            : all uppercase letters
-    lower      | lowercase            : all lowercase letters
-    cap        | capitalize           : uppercase first letter
-    decap      | decapitalize         : lowercase first letter
-    start      | start-case           : uppercase the first letter of each word
-    word       | word-only            : remove all non-word letters (only a-zA-Z0-9_)
-    space      | word-space           : replace all non-word letters (only a-zA-Z0-9) with a whitespace
-    Camel      | upper-camel          : upper camel case (start-case, word-only)
-    camel      | lower-camel          : lower camel case (start-case, word-only, decapitalize)
-    hyphen     | hyphenate            : replace spaces with hyphens
-    norm       | normalize            : all lowercase with hyphens (lowercase, hyphenate)
-    snake      | snake-case           : replace spaces and dots with underscores
-    reverseOrg | reverse-organization : tokenizes by dot and reverses the tokens (scala-lang.org -> org.scala-lang)
-    package    | package-naming       : replace spaces with dots
-    packaged   | package-dir          : replace dots with slashes (net.databinder -> net/databinder)
-    random     | generate-random      : appends random characters to the given string
+    upper      | uppercase       : all uppercase letters
+    lower      | lowercase       : all lowercase letters
+    cap        | capitalize      : uppercase first letter
+    decap      | decapitalize    : lowercase first letter
+    start      | start-case      : uppercase the first letter of each word
+    word       | word-only       : remove all non-word letters (only a-zA-Z0-9_)
+    space      | word-space      : replace all non-word letters (only a-zA-Z0-9) with a whitespace
+    Camel      | upper-camel     : upper camel case (start-case, word-only)
+    camel      | lower-camel     : lower camel case (start-case, word-only, decapitalize)
+    hyphen     | hyphenate       : replace spaces with hyphens
+    norm       | normalize       : all lowercase with hyphens (lowercase, hyphenate)
+    snake      | snake-case      : replace spaces and dots with underscores
+    dotReverse | dot-reverse     : tokenizes by dot and reverses the tokens (scala-lang.org -> org.scala-lang)
+    package    | package-naming  : replace spaces with dots
+    packaged   | package-dir     : replace dots with slashes (net.databinder -> net/databinder)
+    random     | generate-random : appends random characters to the given string
 
 A `name` field with a value of `My Project` could be rendered in several ways:
 

--- a/docs/03/a.md
+++ b/docs/03/a.md
@@ -12,21 +12,22 @@ formatted in upper camel case with:
 
 The formatting options are:
 
-    upper    | uppercase       : all uppercase letters
-    lower    | lowercase       : all lowercase letters
-    cap      | capitalize      : uppercase first letter
-    decap    | decapitalize    : lowercase first letter
-    start    | start-case      : uppercase the first letter of each word
-    word     | word-only       : remove all non-word letters (only a-zA-Z0-9_)
-    space    | word-space      : replace all non-word letters (only a-zA-Z0-9) with a whitespace
-    Camel    | upper-camel     : upper camel case (start-case, word-only)
-    camel    | lower-camel     : lower camel case (start-case, word-only, decapitalize)
-    hyphen   | hyphenate       : replace spaces with hyphens
-    norm     | normalize       : all lowercase with hyphens (lowercase, hyphenate)
-    snake    | snake-case      : replace spaces and dots with underscores
-    package  | package-naming  : replace spaces with dots
-    packaged | package-dir     : replace dots with slashes (net.databinder -> net/databinder)
-    random   | generate-random : appends random characters to the given string
+    upper      | uppercase            : all uppercase letters
+    lower      | lowercase            : all lowercase letters
+    cap        | capitalize           : uppercase first letter
+    decap      | decapitalize         : lowercase first letter
+    start      | start-case           : uppercase the first letter of each word
+    word       | word-only            : remove all non-word letters (only a-zA-Z0-9_)
+    space      | word-space           : replace all non-word letters (only a-zA-Z0-9) with a whitespace
+    Camel      | upper-camel          : upper camel case (start-case, word-only)
+    camel      | lower-camel          : lower camel case (start-case, word-only, decapitalize)
+    hyphen     | hyphenate            : replace spaces with hyphens
+    norm       | normalize            : all lowercase with hyphens (lowercase, hyphenate)
+    snake      | snake-case           : replace spaces and dots with underscores
+    reverseOrg | reverse-organization : tokenizes by dot and reverses the tokens (scala-lang.org -> org.scala-lang)
+    package    | package-naming       : replace spaces with dots
+    packaged   | package-dir          : replace dots with slashes (net.databinder -> net/databinder)
+    random     | generate-random      : appends random characters to the given string
 
 A `name` field with a value of `My Project` could be rendered in several ways:
 

--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -240,7 +240,7 @@ object G8 {
   def snakeCase(s: String)       = s.replaceAll("""[\s\.\-]+""", "_")
   def packageNaming(s: String)   = s.replaceAll("""\s+""", ".")
   def packageDir(s: String)      = s.replace(".", System.getProperty("file.separator"))
-  def reverseOrg(s: String)      = s.split('.').reverse.mkString(".")
+  def dotReverse(s: String)      = s.split('.').reverse.mkString(".")
   def addRandomId(s: String)     = s + "-" + new java.math.BigInteger(256, new java.security.SecureRandom).toString(32)
   def scalaIdentifier(s: String) = if (s.contains("-")) "`" + s + "`" else s
 
@@ -590,22 +590,22 @@ class AugmentedStringRenderer {
   }
 
   def format(value: String, formatName: String): String = formatName match {
-    case "upper"      | "uppercase"            => value.toUpperCase
-    case "lower"      | "lowercase"            => value.toLowerCase
-    case "cap"        | "capitalize"           => value.capitalize
-    case "decap"      | "decapitalize"         => decapitalize(value)
-    case "start"      | "start-case"           => startCase(value)
-    case "word"       | "word-only"            => wordOnly(value)
-    case "space"      | "word-space"           => space(value)
-    case "Camel"      | "upper-camel"          => upperCamel(value)
-    case "camel"      | "lower-camel"          => lowerCamel(value)
-    case "hyphen"     | "hyphenate"            => hyphenate(value)
-    case "norm"       | "normalize"            => normalize(value)
-    case "snake"      | "snake-case"           => snakeCase(value)
-    case "package"    | "package-naming"       => packageNaming(value)
-    case "packaged"   | "package-dir"          => packageDir(value)
-    case "reverseOrg" | "reverse-organization" => reverseOrg(value)
-    case "random"     | "generate-random"      => addRandomId(value)
+    case "upper"      | "uppercase"       => value.toUpperCase
+    case "lower"      | "lowercase"       => value.toLowerCase
+    case "cap"        | "capitalize"      => value.capitalize
+    case "decap"      | "decapitalize"    => decapitalize(value)
+    case "start"      | "start-case"      => startCase(value)
+    case "word"       | "word-only"       => wordOnly(value)
+    case "space"      | "word-space"      => space(value)
+    case "Camel"      | "upper-camel"     => upperCamel(value)
+    case "camel"      | "lower-camel"     => lowerCamel(value)
+    case "hyphen"     | "hyphenate"       => hyphenate(value)
+    case "norm"       | "normalize"       => normalize(value)
+    case "snake"      | "snake-case"      => snakeCase(value)
+    case "package"    | "package-naming"  => packageNaming(value)
+    case "packaged"   | "package-dir"     => packageDir(value)
+    case "dotReverse" | "dot-reverse"     => dotReverse(value)
+    case "random"     | "generate-random" => addRandomId(value)
     case _ => value
   }
 }

--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -240,6 +240,7 @@ object G8 {
   def snakeCase(s: String)       = s.replaceAll("""[\s\.\-]+""", "_")
   def packageNaming(s: String)   = s.replaceAll("""\s+""", ".")
   def packageDir(s: String)      = s.replace(".", System.getProperty("file.separator"))
+  def reverseOrg(s: String)      = s.split('.').reverse.mkString(".")
   def addRandomId(s: String)     = s + "-" + new java.math.BigInteger(256, new java.security.SecureRandom).toString(32)
   def scalaIdentifier(s: String) = if (s.contains("-")) "`" + s + "`" else s
 
@@ -589,21 +590,22 @@ class AugmentedStringRenderer {
   }
 
   def format(value: String, formatName: String): String = formatName match {
-    case "upper"    | "uppercase"       => value.toUpperCase
-    case "lower"    | "lowercase"       => value.toLowerCase
-    case "cap"      | "capitalize"      => value.capitalize
-    case "decap"    | "decapitalize"    => decapitalize(value)
-    case "start"    | "start-case"      => startCase(value)
-    case "word"     | "word-only"       => wordOnly(value)
-    case "space"    | "word-space"      => space(value)
-    case "Camel"    | "upper-camel"     => upperCamel(value)
-    case "camel"    | "lower-camel"     => lowerCamel(value)
-    case "hyphen"   | "hyphenate"       => hyphenate(value)
-    case "norm"     | "normalize"       => normalize(value)
-    case "snake"    | "snake-case"      => snakeCase(value)
-    case "package"  | "package-naming"  => packageNaming(value)
-    case "packaged" | "package-dir"     => packageDir(value)
-    case "random"   | "generate-random" => addRandomId(value)
+    case "upper"      | "uppercase"            => value.toUpperCase
+    case "lower"      | "lowercase"            => value.toLowerCase
+    case "cap"        | "capitalize"           => value.capitalize
+    case "decap"      | "decapitalize"         => decapitalize(value)
+    case "start"      | "start-case"           => startCase(value)
+    case "word"       | "word-only"            => wordOnly(value)
+    case "space"      | "word-space"           => space(value)
+    case "Camel"      | "upper-camel"          => upperCamel(value)
+    case "camel"      | "lower-camel"          => lowerCamel(value)
+    case "hyphen"     | "hyphenate"            => hyphenate(value)
+    case "norm"       | "normalize"            => normalize(value)
+    case "snake"      | "snake-case"           => snakeCase(value)
+    case "package"    | "package-naming"       => packageNaming(value)
+    case "packaged"   | "package-dir"          => packageDir(value)
+    case "reverseOrg" | "reverse-organization" => reverseOrg(value)
+    case "random"     | "generate-random"      => addRandomId(value)
     case _ => value
   }
 }

--- a/library/src/test/scala/FormatSpecification.scala
+++ b/library/src/test/scala/FormatSpecification.scala
@@ -41,6 +41,10 @@ object FormatSpecification extends Properties("Format") {
 
   property("formatPackageNaming") = conversion("""$x;format="package"$""", Map("x" -> "foo bar  baz")) == "foo.bar.baz"
 
+  property("formatReverseOrg") = forAll(nonDotNonDollar, nonDotNonDollar, nonDotNonDollar) { (x, y, z) =>
+    conversion("""$k;format="reverse-organization"$""", Map("k" -> s"$x.$y.$z")) == s"$z.$y.$x"
+  }
+
   lazy val hiragana = (0x3041 to 0x3094).toList
 
   lazy val nonDollarChar: Gen[Char] = Gen.oneOf(
@@ -56,6 +60,16 @@ object FormatSpecification extends Properties("Format") {
 
   lazy val asciiString: Gen[String] = Gen.sized { size =>
     Gen.listOfN(size, asciiChar).map(_.mkString)
+  } filter { _.nonEmpty }
+
+  lazy val nonDotNonDollarChar: Gen[Char] = Gen.oneOf(
+    ((0x20 to 0xff).toList ::: hiragana)
+      .filter(x => Character.isDefined(x) && x != 0x2e && x != 0x24 && x != 0x5c)
+      .map(_.toChar)
+  )
+
+  lazy val nonDotNonDollar: Gen[String] = Gen.sized { size =>
+    Gen.listOfN(size, nonDotNonDollarChar).map(_.mkString)
   } filter { _.nonEmpty }
 
   def conversion(inContent: String, ps: Map[String, String]): String = synchronized {

--- a/library/src/test/scala/FormatSpecification.scala
+++ b/library/src/test/scala/FormatSpecification.scala
@@ -41,8 +41,8 @@ object FormatSpecification extends Properties("Format") {
 
   property("formatPackageNaming") = conversion("""$x;format="package"$""", Map("x" -> "foo bar  baz")) == "foo.bar.baz"
 
-  property("formatReverseOrg") = forAll(nonDotNonDollar, nonDotNonDollar, nonDotNonDollar) { (x, y, z) =>
-    conversion("""$k;format="reverse-organization"$""", Map("k" -> s"$x.$y.$z")) == s"$z.$y.$x"
+  property("formatDotReverse") = forAll(nonDotNonDollar, nonDotNonDollar, nonDotNonDollar) { (x, y, z) =>
+    conversion("""$k;format="dot-reverse"$""", Map("k" -> s"$x.$y.$z")) == s"$z.$y.$x"
   }
 
   lazy val hiragana = (0x3041 to 0x3094).toList


### PR DESCRIPTION
I added a string formatter with an unhappy name (naming is not my best skill) that tokenizes a string using the `'.'` character and reverses the order of the tokens.
The use case I had in mind is the `organization` vs `organizationName` keys that a lot of times (at least for me) are simply derivable one from the other, eg. `organizationName := "github.com"` and `organization := "com.github"`
I added a property based test and updated the english documentation.