### PR TITLE
Add coursier based installation instructions

### DIFF
--- a/docs/01.md
+++ b/docs/01.md
@@ -5,6 +5,8 @@ out: setup.html
 Setup
 -----
 
+#### Conscript
+
 You can install Giter8 and other Scala command line tools with
 [Conscript][cs]. This will setup Conscript in `~/.conscript/bin/cs`:
 
@@ -24,8 +26,15 @@ a usage message.
 When it's time to upgrade to a new version of giter8, just run the
 same `cs` command again.
 
-Giter8 is also installable with the OS X package manager [Homebrew][]:
+#### Coursier
 
-    \$ brew update && brew install giter8
+Giter8 and other Scala command line tools can be installed using [Coursier](https://get-coursier.io/). 
+See the coursier [installation instruction](https://get-coursier.io/docs/cli-installation) to add it to your path.
+Pay attention to the binary name since it's `cs` as the Conscript binary. Once `cs` is
+on your path, you can install giter8 with this command:
 
-[Homebrew]: https://brew.sh
+    cs install giter8
+
+and update it using:
+
+    cs update giter8

--- a/docs/01.md
+++ b/docs/01.md
@@ -5,36 +5,25 @@ out: setup.html
 Setup
 -----
 
-#### Conscript
-
-You can install Giter8 and other Scala command line tools with
-[Conscript][cs]. This will setup Conscript in `~/.conscript/bin/cs`:
-
-    curl https://raw.githubusercontent.com/foundweekends/conscript/master/setup.sh | sh
-
-(See [Conscript's readme][cs] for a non-unixy option.) Once `cs` is
-on your path, you can install (or upgrade) giter8 with this command:
-
-    cs foundweekends/giter8
-
-[cs]: http://www.foundweekends.org/conscript/setup.html
-
-To make sure everything is working, try running `g8` with no
-parameters. This should download giter8 and its dependencies, then print
-a usage message.
-
-When it's time to upgrade to a new version of giter8, just run the
-same `cs` command again.
-
 #### Coursier
 
 Giter8 and other Scala command line tools can be installed using [Coursier](https://get-coursier.io/). 
 See the coursier [installation instruction](https://get-coursier.io/docs/cli-installation) to add it to your path.
-Pay attention to the binary name since it's `cs` as the Conscript binary. Once `cs` is
-on your path, you can install giter8 with this command:
+Once `cs` is on your path, you can install giter8 with this command:
 
-    cs install giter8
+    \$ cs install giter8
 
 and update it using:
 
-    cs update g8
+    \$ cs update g8
+
+#### Manual
+
+It's possible to manually download and install giter8 directly from Maven Central:
+
+    \$ curl https://repo1.maven.org/maven2/org/foundweekends/giter8/giter8-bootstrap_2.12/0.13.1/giter8-bootstrap_2.12-0.13.1.sh > ~/bin/g8
+    \$ chmod +x ~/bin/g8
+
+Replace `~/bin/` with anything that is on your `PATH`. To make sure everything is working, try running `g8` with no
+parameters, 
+

--- a/docs/01.md
+++ b/docs/01.md
@@ -37,4 +37,4 @@ on your path, you can install giter8 with this command:
 
 and update it using:
 
-    cs update giter8
+    cs update g8


### PR DESCRIPTION
I added the Coursier based installation instructions, removing the Homebrew ones since the formula was disabled (see #475). I focused on the name clash between Conscript and Coursier, but there wasn't an obvious solution for that, so I just pointed out the possible issue. 

Please review my English. 😓 
Closes #545.