### PR TITLE
Enable description as a property in templates

### DIFF
--- a/docs/01.md
+++ b/docs/01.md
@@ -25,5 +25,7 @@ It's possible to manually download and install giter8 directly from Maven Centra
     \$ chmod +x ~/bin/g8
 
 Replace `~/bin/` with anything that is on your `PATH`. To make sure everything is working, try running `g8` with no
-parameters.
+parameters, you should see
 
+    Error: Missing argument <template>
+    Try --help for more information. 

--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -429,9 +429,7 @@ object G8 {
   }
 
   def interact(params: UnresolvedProperties): ResolvedProperties = {
-    val (desc, others) = params partition { case (k, _) => k == "description" }
-
-    desc.foreach { d =>
+    params.filter(_._1 == "description").foreach { d =>
       @scala.annotation.tailrec
       def liner(cursor: Int, rem: Iterable[String]): Unit = {
         if (!rem.isEmpty) {
@@ -453,10 +451,10 @@ object G8 {
     val fixed    = Set("verbatim")
     val renderer = new AugmentedStringRenderer
 
-    others
+    params
       .foldLeft(ResolvedProperties.empty) { case (resolved, (k, f)) =>
         resolved + (
-          if (fixed.contains(k))
+          if (fixed.contains(k) || k == "description")
             k -> f(resolved)
           else {
             val default = f(resolved)

--- a/library/src/test/scala/giter8/IntegrationTest.scala
+++ b/library/src/test/scala/giter8/IntegrationTest.scala
@@ -103,6 +103,14 @@ class IntegrationTest extends AnyFlatSpec with IntegrationTestHelpers with Match
     checkGeneratedProject(template, expected, actual)
   }
 
+  it should "read default.properties with description parameter from root directory" in testCase {
+    case (template, expected, actual) =>
+      "foo = bar\ndescription = my description" >> (template / "src" / "main" / "g8" / "default.properties")
+      "$foo$ $description$" >> (template / "src" / "main" / "g8" / "foo.txt")
+      "bar my description" >> (expected / "foo.txt")
+      checkGeneratedProject(template, expected, actual)
+  }
+
   it should "resolve package names" in testCase { case (template, expected, actual) =>
     """|name = Package test
        |package = com.example


### PR DESCRIPTION
In PR #320 a test was added to check whether `description` can be used as a property within the template.
With this modification, the test passes, plus when tested locally the property can be used in templates.
This should address #321 and #99. Plus if this passes CI then #320 can be closed too.