### PR TITLE
Documenting template comment syntax

### DIFF
--- a/docs/03/00.md
+++ b/docs/03/00.md
@@ -94,7 +94,7 @@ Dollar signs can be escaped to avoid resolution:
 ```
 val foo = "foo"
 val bar = "bar"
-println(s"\\$foo\\$bar")
+println(s"\\\$foo\\\$bar")
 ```
 
 This would yield to:
@@ -103,6 +103,31 @@ This would yield to:
 val foo = "foo"
 val bar = "bar"
 println(s"\$foo\$bar")
+```
+
+### Template comments
+
+Sometimes it's useful to put a comment into a template that is intended for 
+template maintainers, and should not be included in the generated output.
+
+Wrapping comments between `\$!` and `!\$` won't make them appear in the output.
+
+```
+\$! This comment won't appear in the output !\$
+// This comment will appear in the output
+\$!
+This multiline comment won't appear either
+No matter how
+long it is
+
+Internal \$substitutions\$ are ignored.
+
+Even \$invalid\$ ones.
+
+!\$
+/*
+ * This comment is output and can contain \$substitutions\$
+ */
 ```
 
 ### Conditionals


### PR DESCRIPTION
Closes #273.

Plus should fix an issue with the current [Making your own template](http://www.foundweekends.org/giter8/template.html) page that is truncated due to a missing `\` in a block of code.