### PR TITLE
Added fix for auth_fail

### DIFF
--- a/cli-git/src/main/scala/GitInteractor.scala
+++ b/cli-git/src/main/scala/GitInteractor.scala
@@ -21,7 +21,7 @@ import java.io.File
 
 import giter8.GitInteractor.TransportError
 import org.eclipse.jgit.api.errors.TransportException
-import org.eclipse.jgit.transport.{CredentialsProvider, SshSessionFactory, SshTransport}
+import org.eclipse.jgit.transport.{CredentialsProvider, SshTransport}
 import org.eclipse.jgit.api.{Git => JGit}
 
 import scala.util.{Failure, Success, Try}
@@ -51,7 +51,7 @@ class JGitInteractor(knownHosts: Option[String]) extends GitInteractor {
       .setCredentialsProvider(ConsoleCredentialsProvider)
       .setTransportConfigCallback({
         case sshTransport: SshTransport => sshTransport.setSshSessionFactory(new SshAgentSessionFactory(knownHosts))
-        case x                          => x
+        case x                          => ()
       })
       .call()
       .close()

--- a/cli-git/src/main/scala/SshAgentSessionFactory.scala
+++ b/cli-git/src/main/scala/SshAgentSessionFactory.scala
@@ -1,39 +1,30 @@
 package giter8
 
-import java.nio.file.{Files, Paths}
+import org.eclipse.jgit.transport.sshd.SshdSessionFactory
+import java.{util => ju}
+import java.io.File
+import java.nio.file.{Path, Files, Paths}
+import scala.collection.JavaConverters._
 
-import com.jcraft.jsch.agentproxy.{ConnectorFactory, RemoteIdentityRepository}
-import com.jcraft.jsch.{JSch, Session}
-import org.eclipse.jgit.transport.{JschConfigSessionFactory, OpenSshConfig}
-import org.eclipse.jgit.util.FS
+class SshAgentSessionFactory(knownHosts: Option[String]) extends SshdSessionFactory() {
 
-class SshAgentSessionFactory(knownHosts: Option[String]) extends JschConfigSessionFactory() {
+  private val home        = Option(System.getProperty("user.home")).getOrElse("")
+  private val programData = Option(System.getenv("PROGRAMDATA")).getOrElse("")
 
-  private val Home        = Option(System.getProperty("user.home")).getOrElse("")
-  private val ProgramData = Option(System.getenv("PROGRAMDATA")).getOrElse("")
-
-  private val KnownHostsPaths: List[String] = List(
-    s"$Home/.ssh/known_hosts",
+  private val defaultKnownHosts: List[String] = List(
+    s"$home/.ssh/known_hosts",
+    s"$home/.ssh/known_hosts2",
     "/etc/ssh/ssh_known_hosts",
-    s"$ProgramData/ssh/ssh_known_hosts"
+    s"$programData/ssh/ssh_known_hosts"
   )
 
-  override protected def configure(host: OpenSshConfig.Host, session: Session): Unit = {}
-
-  override protected def createDefaultJSch(fs: FS): JSch = {
-    val jsch = new JSch()
-    knownHostsWithDefault.foreach(jsch.setKnownHosts)
-    jsch.setIdentityRepository(identityRepository)
-    jsch
+  override def getDefaultKnownHostsFiles(sshDir: File): ju.List[Path] = {
+    knownHosts
+      .map(_ :: Nil)
+      .getOrElse(defaultKnownHosts)
+      .map(Paths.get(_))
+      .filter(Files.exists(_))
+      .asJava
   }
 
-  private def knownHostsWithDefault = {
-    knownHosts.orElse(KnownHostsPaths.find(path => Files.exists(Paths.get(path))))
-  }
-
-  private def identityRepository = {
-    val factory   = ConnectorFactory.getDefault
-    val connector = factory.createConnector
-    new RemoteIdentityRepository(connector)
-  }
 }


### PR DESCRIPTION
I think I found a working fix for the famous `auth fail` problem that occurs with private repositories or in the case of custom configurations like when you have a `~/.ssh/config`

I've tried to keep the philosophy introduced by @steinybot  with [this commit](https://github.com/foundweekends/giter8/commit/8d7cac6e4a4d9634a139ce5f100db9d62d2fc2dd#diff-ec91a1881c7b5ed50e572c7e8b068a18139c8d4e2d69eeccc9f0d7cf5f10c64e) and [the following](https://github.com/foundweekends/giter8/commit/90e597723e84d103d0c2f536bc5dbbc7f35ed7f3#diff-ec91a1881c7b5ed50e572c7e8b068a18139c8d4e2d69eeccc9f0d7cf5f10c64e)

The main idea is that PROBABLY the `JschConfigSessionFactory` that was overridden before cannot read custom ssh configurations, identity files or keys, while the default implementation `SshdSessionFactory` "mina-sshd" by apache seems to be able to.

I spotted the working implementation simply commenting [this line](https://github.com/foundweekends/giter8/blob/develop/cli-git/src/main/scala/GitInteractor.scala#L53) and printing `x` one the next one. Since not using `SshAgentSessionFactory` worked for me and my custom configuration I thought it could have been a good starting point.

To keep the "custom known_host" configurability option I used the input `knownHosts: Option[String]` to override  `getDefaultKnownHostsFiles`.

I'll keep this PR as a draft until a consistent number of people might be able to test it.

In order to test it, the easiest way is to checkout this PR and then
```
sbt publishLocal
cs bootstrap org.foundweekends.giter8:giter8-launcher_2.12:0.13.1-SNAPSHOT --main giter8.LauncherMain -f -o ~/Desktop/g8-test
./g8-test <ssh:// or git@ URL of a repo>
```

If it works it should:
 - close #117 
 - close #163 
 - close #326 
 - close #131

and probably #176 and #548 too