### PR TITLE
Add support for multiline description; remove 70 chars limitation

### DIFF
--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -438,10 +438,24 @@ object G8 {
           getDescription(ResolvedProperties.empty)
       }
 
-    println()
-
     description.foreach { descr =>
-      println(descr)
+      descr.split("\n").foreach { line =>
+        @scala.annotation.tailrec
+        def liner(cursor: Int, rem: Iterable[String]): Unit = {
+          if (rem.nonEmpty) {
+            val next = cursor + 1 + rem.head.length
+            if (next > 70 && cursor > 0) {
+              println()
+              liner(0, rem)
+            } else {
+              print(rem.head + " ")
+              liner(next, rem.tail)
+            }
+          }
+        }
+        liner(0, line.split(" "))
+        println()
+      }
       println()
     }
 

--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -432,32 +432,24 @@ object G8 {
   }
 
   def interact(params: UnresolvedProperties): ResolvedProperties = {
-    params.filter(_._1 == "description").foreach { d =>
-      @scala.annotation.tailrec
-      def liner(cursor: Int, rem: Iterable[String]): Unit = {
-        if (!rem.isEmpty) {
-          val next = cursor + 1 + rem.head.length
-          if (next > 70) {
-            println()
-            liner(0, rem)
-          } else {
-            print(rem.head + " ")
-            liner(next, rem.tail)
-          }
-        }
+    val description = params
+      .collectFirst { case (param, getDescription) if param == "description" =>
+        getDescription(ResolvedProperties.empty)
       }
+
+    println()
+
+    description.foreach { descr =>
+      println(descr)
       println()
-      liner(0, d._2(ResolvedProperties.empty).split(" "))
-      println("\n")
     }
 
-    val fixed = Set("verbatim")
+    val fixed = Set("verbatim", "description")
 
     params
       .foldLeft(ResolvedProperties.empty) { case (resolved, (k, f)) =>
         resolved + (
-          if (fixed.contains(k) || k == "description")
-            k -> f(resolved)
+          if (fixed.contains(k)) k -> f(resolved)
           else {
             val default = f(resolved)
             val message = Truthy.getMessage(default)

--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -433,8 +433,9 @@ object G8 {
 
   def interact(params: UnresolvedProperties): ResolvedProperties = {
     val description = params
-      .collectFirst { case (param, getDescription) if param == "description" =>
-        getDescription(ResolvedProperties.empty)
+      .collectFirst {
+        case (param, getDescription) if param == "description" =>
+          getDescription(ResolvedProperties.empty)
       }
 
     println()

--- a/library/src/main/scala/giter8/MavenHelper.scala
+++ b/library/src/main/scala/giter8/MavenHelper.scala
@@ -17,9 +17,7 @@
 
 package giter8
 
-import java.net.{URL, HttpURLConnection}
-import java.io.{BufferedReader, InputStreamReader}
-import java.util.stream.Collectors
+import java.net.{HttpURLConnection, URL}
 import scala.xml.{NodeSeq, XML}
 
 trait MavenHelper {

--- a/library/src/test/scala/giter8/IntegrationTest.scala
+++ b/library/src/test/scala/giter8/IntegrationTest.scala
@@ -116,7 +116,8 @@ class IntegrationTest extends AnyFlatSpec with IntegrationTestHelpers with Match
       """description = \
         |  this is multiline\n\
         |  with another line\n\
-        |  long description
+        |  long long long long long long long long long long long long long long description within the line\n\
+        |  the end.
         |
         |foo = bar
         |""".stripMargin >> (template / "src" / "main" / "g8" / "default.properties")
@@ -124,7 +125,8 @@ class IntegrationTest extends AnyFlatSpec with IntegrationTestHelpers with Match
 
       """bar this is multiline
         |with another line
-        |long description
+        |long long long long long long long long long long long long long long description within the line
+        |the end.
         |""".stripMargin >> (expected / "foo.txt")
       checkGeneratedProject(template, expected, actual)
   }

--- a/library/src/test/scala/giter8/IntegrationTest.scala
+++ b/library/src/test/scala/giter8/IntegrationTest.scala
@@ -111,6 +111,24 @@ class IntegrationTest extends AnyFlatSpec with IntegrationTestHelpers with Match
       checkGeneratedProject(template, expected, actual)
   }
 
+  it should "read default.properties with multiline description parameter from root directory" in testCase {
+    case (template, expected, actual) =>
+      """description = \
+        |  this is multiline\n\
+        |  with another line\n\
+        |  long description
+        |
+        |foo = bar
+        |""".stripMargin >> (template / "src" / "main" / "g8" / "default.properties")
+      "$foo$ $description$" >> (template / "src" / "main" / "g8" / "foo.txt")
+
+      """bar this is multiline
+        |with another line
+        |long description
+        |""".stripMargin >> (expected / "foo.txt")
+      checkGeneratedProject(template, expected, actual)
+  }
+
   it should "resolve package names" in testCase { case (template, expected, actual) =>
     """|name = Package test
        |package = com.example

--- a/library/src/test/scala/giter8/IntegrationTestHelpers.scala
+++ b/library/src/test/scala/giter8/IntegrationTestHelpers.scala
@@ -51,7 +51,7 @@ trait IntegrationTestHelpers {
     val actualLines   = Source.fromFile(actual).getLines().toSeq
     val expectedLines = Source.fromFile(expected).getLines().toSeq
     expectedLines.zipWithIndex foreach { case (line, i) =>
-      assert(line == actualLines(i), s"in file $path:$i")
+      assert(actualLines(i) == line, s"in file $path:$i")
     }
   }
 


### PR DESCRIPTION
fixes #596

This PR aim for supporting multiline description, with custom line breaks and removing custom 70 symbols pseudo new line
As for me it can be obsoleted since it's now up to you how to format the description

Example:
```
description = \
Welcome to AG scala service seed!\n\
Let's create service with our best practices!\n\
\n\
Help about parameters:\n\
- organization => logical separation, part of package name (eg. platform, connectivity, ..)\n\
- project => human-readable name of the project. Do not include 'api' postfix in it\n\
- ssot => system name that we use internally to identify the service. This name may include 'api' postfix\n\
- git_* => gitlab settings\n\
- harbor_organization => allows to override harbor organization
- gen_* => whether to include generation of dedicated components; yes / no\n\
```

As a result we'll have nice description in the console:
```
Welcome to AG scala service seed!
Let's create service with our best practices!

Help about parameters:
- organization => logical separation, part of package name (eg. platform, connectivity, ..)
- project => human-readable name of the project. Do not include 'api' postfix in it
- ssot => system name that we use internally to identify the service. This name may include 'api' postfix
- git_* => gitlab settings
- harbor_organization => allows to override harbor organization
- gen_* => whether to include generation of dedicated components; yes / no
```