### PR TITLE
Dependency optimization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -141,10 +141,7 @@ lazy val gitsupport = (project in file("cli-git"))
     libraryDependencies ++= Seq(
       scopt,
       jgit,
-      jsch,
-      jschSshAgent,
-      jschConnectorFactory,
-      jgitJsch,
+      jgitSshApache,
       commonsIo,
       scalatest % Test,
       scalamock % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,15 +9,8 @@ object Dependencies {
     ExclusionRule("org.tukaani", "xz"),
     ExclusionRule("junit", "junit")
   )
-  val jgit = "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "5.13.1.202206130422-r" excludeAll (
-    ExclusionRule("javax.jms", "jms"),
-    ExclusionRule("com.sun.jdmk", "jmxtools"),
-    ExclusionRule("com.sun.jmx", "jmxri")
-  )
-  val jgitJsch             = "org.eclipse.jgit" % "org.eclipse.jgit.ssh.jsch" % "5.13.1.202206130422-r"
-  val jsch                 = "com.jcraft" % "jsch.agentproxy.jsch" % "0.0.9"
-  val jschSshAgent         = "com.jcraft" % "jsch.agentproxy.sshagent" % "0.0.9"
-  val jschConnectorFactory = "com.jcraft" % "jsch.agentproxy.connector-factory" % "0.0.9"
+  val jgit                 = "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.1.202206130422-r"
+  val jgitSshApache        = "org.eclipse.jgit" % "org.eclipse.jgit.ssh.apache" % "5.13.1.202206130422-r"
   val scopt                = "com.github.scopt" %% "scopt" % "4.1.0"
   val scalacheck           = "org.scalacheck" %% "scalacheck" % "1.16.0"
   val scalatest            = "org.scalatest" %% "scalatest" % "3.2.12"


### PR DESCRIPTION
The following commit switches SSH-related libraries from `jsch` to `Apache Mina`,
so unnecessary dependencies on `jsch` can be removed.

https://github.com/foundweekends/giter8/commit/c51d1711815db44cc4458b81b286ad26c9132598

Also, since `org.eclipse.jgit.pgm` contains many libraries that are not needed in Giter8,
it is more appropriate to minimize it to just `org.eclipse.jgit` and `org.eclipse.jgit.ssh.apach`.