### PR TITLE
Updated plexus-archiver

### DIFF
--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -22,8 +22,6 @@ import java.util.regex.Matcher
 import java.util.{Locale, Properties}
 
 import org.apache.commons.io.FileUtils
-import org.codehaus.plexus.logging.Logger
-import org.codehaus.plexus.logging.console.ConsoleLogger
 import org.codehaus.plexus.archiver.util.ArchiveEntryUtils
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributeUtils
 import org.stringtemplate.v4.compiler.STException
@@ -179,7 +177,7 @@ object G8 {
         case Some(attr) =>
           val mode = attr.getOctalMode
           write(out, FileUtils.readFileToString(in, "UTF-8"), parameters /*, append*/ )
-          Try(ArchiveEntryUtils.chmod(out, mode, new ConsoleLogger(Logger.LEVEL_ERROR, "")))
+          Try(ArchiveEntryUtils.chmod(out, mode))
         case None =>
           // PlexusIoResourceAttributes is not available for some OS'es such as windows
           write(out, FileUtils.readFileToString(in, "UTF-8"), parameters /*, append*/ )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val stringTemplate = "org.antlr" % "ST4" % "4.3.3"
   val commonsIo      = "commons-io" % "commons-io" % "2.11.0"
-  val plexusArchiver = "org.codehaus.plexus" % "plexus-archiver" % "2.7.1" excludeAll (
+  val plexusArchiver = "org.codehaus.plexus" % "plexus-archiver" % "4.4.0" excludeAll (
     ExclusionRule("org.apache.commons", "commons-compress"),
     ExclusionRule("classworlds", "classworlds"),
     ExclusionRule("org.tukaani", "xz"),


### PR DESCRIPTION
Replaced ArchiveEntryUtils.chmod that takes Logger as an argument
with ArchiveEntryUtils.chmod that does not take Logger as an argument,
since it is now deprecated