### PR TITLE
Removed ScriptedPlugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ lazy val crossSbt = Seq(
 )
 
 lazy val scaffold = (project in file("scaffold"))
-  .enablePlugins(SbtPlugin, SonatypePublish, ScriptedPlugin)
+  .enablePlugins(SbtPlugin, SonatypePublish)
   .dependsOn(lib)
   .settings(crossSbt)
   .settings(
@@ -99,7 +99,7 @@ lazy val scaffold = (project in file("scaffold"))
   )
 
 lazy val plugin = (project in file("plugin"))
-  .enablePlugins(SbtPlugin, SonatypePublish, ScriptedPlugin)
+  .enablePlugins(SbtPlugin, SonatypePublish)
   .dependsOn(lib)
   .settings(crossSbt)
   .settings(

--- a/plugin/src/sbt-test/giter8/simple/build.sbt
+++ b/plugin/src/sbt-test/giter8/simple/build.sbt
@@ -1,7 +1,3 @@
-enablePlugins(ScriptedPlugin)
-
-scriptedBufferLog in (Test, g8) := false
-
 TaskKey[Unit]("writeInvalidFile") := {
   IO.write(file("src/main/g8/src/test/scala/invalid.scala"), "invalid file")
 }

--- a/plugin/src/sbt-test/giter8/without-name/build.sbt
+++ b/plugin/src/sbt-test/giter8/without-name/build.sbt
@@ -1,7 +1,3 @@
-enablePlugins(ScriptedPlugin)
-
-scriptedBufferLog in (Test, g8) := false
-
 val javaVmArgs: List[String] = {
   import scala.collection.JavaConverters._
   java.lang.management.ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.toList


### PR DESCRIPTION
 - Since sbt 1.2, ScriptedPlugin has been integrated into SbtPlugin,
   so unnecessary specifications have been removed from build.sbt.
 - ScriptedPlugin was specified in build.sbt on the Script Test side,
   but this is unnecessary and was removed.
   Also, the scriptedBufferLog specification was removed because it
   was unnecessary.Both should be specified on the plugin side.