### PR TITLE
Fixed installation instructions

### DIFF
--- a/docs/ja/01.md
+++ b/docs/ja/01.md
@@ -21,9 +21,3 @@ Giter8 や他の Scala コマンドラインツールは [Conscript][cs]
 Giter8 とその依存ライブラリがダウンロードされて使用方法が表示されるはずだ。
 
 アップグレードするときも同じ `cs` コマンドを実行すればいい。
-
-Giter8 は OS X のパッケージマネジャーである [Homebrew][] からもインストール可能だ:
-
-    \$ brew update && brew install giter8
-
-[Homebrew]: https://brew.sh

--- a/docs/ko/01.md
+++ b/docs/ko/01.md
@@ -21,9 +21,3 @@ PATH가 적용되어, `cs` 명령을 실행할 수 있는 위치에서、아래�
 Giter8 와 종속 라이브러리가 다운로드되어, 사용방법이 표시됩니다.
 
 업그레이드 시에도 같은 `cs` 실행하면 됩니다.
-
-Giter8 는 OS X 의 패키지 매니져인 [Homebrew][] 를 통해서도 설치가 가능 합니다.
-
-    \$ brew update && brew install giter8
-
-[Homebrew]: https://brew.sh


### PR DESCRIPTION
Fomula in Giter8 has been removed and is inconsistent with the documentation.

https://github.com/Homebrew/homebrew-core/commit/c161621f46e90a1341ae591bc57b86ed1d4318b0

Fomula may be reinstated in the future, but the documentation should be corrected.