### PR TITLE
Downgrade scala-parser-combinators to 1.x because of version conflicts

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val scala213         = "2.13.9"
   val sbt1             = "1.2.8"
   val scalaXml         = "org.scala-lang.modules" %% "scala-xml" % "2.1.0"
-  val parserCombinator = "org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.1"
+  val parserCombinator = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
   val logback          = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val coursier         = "io.get-coursier" %% "coursier" % "2.0.16"
   val launcherIntf     = "org.scala-sbt" % "launcher-interface" % "1.4.1"


### PR DESCRIPTION
Reproducer:
```bash
sbt new playframework/play-scala-seed.g8
cd play-scala-seed/
# Edit project/plugins.sbt, change sbt-giter8-scaffold version to 0.15.0
# Now run sbt:
sbt
```
You end up with:
```
[error]         * org.scala-lang.modules:scala-parser-combinators_2.12:2.1.1 (early-semver) is selected over {1.1.2, 1.1.1}
[error]             +- org.foundweekends.giter8:giter8-lib_2.12:0.15.0    (depends on 2.1.1)
[error]             +- com.typesafe.sbt:sbt-native-packager:1.5.2 (scalaVersion=2.12, sbtVersion=1.0) (depends on 1.1.1)
[error]             +- com.typesafe.play:sbt-routes-compiler_2.12:2.8.16  (depends on 1.1.2)
```

The problem is that most sbt plugins didn't upgrade to scala-parser-combinators v2 yet, so that's why this version conflicts occur.
Even the latest release of Scala 2.12 stays on v1 for now: https://github.com/scala/scala/blob/v2.12.17/versions.properties#L22
(But they did upgrade to scala-xml 2.x in 2.12.17 release however)

That's why I think it makes sense to downgrade in giter8 for now, until there is like a consens in the Scala world when plugins (that run on Scala 2.12) upgrade to v2. (That happened with scala-xml recently, where the scala-compiler and many sbt plugins upgraded scala-xml to v2)

Would it be possible to release 0.15.1 or 0.16 with that pr merged? Thanks!