### PR TITLE
deps: exclude sshd-sftp

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,8 +9,14 @@ object Dependencies {
     ExclusionRule("org.tukaani", "xz"),
     ExclusionRule("junit", "junit")
   )
-  val jgit             = "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.1.202206130422-r"
-  val jgitSshApache    = "org.eclipse.jgit" % "org.eclipse.jgit.ssh.apache" % "5.13.1.202206130422-r"
+  // We excluded sshd-sftp to avoid https://github.com/advisories/GHSA-fhw8-8j55-vwgq
+  // Either that or we need to bump to jgit 6.x
+  val jgit = "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.1.202206130422-r" excludeAll (
+    ExclusionRule("org.apache.sshd", "sshd-sftp")
+  )
+  val jgitSshApache = "org.eclipse.jgit" % "org.eclipse.jgit.ssh.apache" % "5.13.1.202206130422-r" excludeAll (
+    ExclusionRule("org.apache.sshd", "sshd-sftp")
+  )
   val scopt            = "com.github.scopt" %% "scopt" % "4.1.0"
   val scalacheck       = "org.scalacheck" %% "scalacheck" % "1.17.0"
   val scalatest        = "org.scalatest" %% "scalatest" % "3.2.14"


### PR DESCRIPTION
The reason for this pr is that the jgit version that is being used
brings in sshd-common (which is brought in by sshd-sftp) which has a
critical security vulnerability attached to it meaning GitHub complains.
You can see the advisory in https://github.com/advisories/GHSA-fhw8-8j55-vwgq.

I wasn't sure if I should pin or exclude, but I didn't see anything that
would use this and saw other exclusions, so I figured this was fine.

Note that another way to avoid this would be to bump jgit to the 6.x,
but I understand you don't want to do that as they drop support for Java
8.
