### PR TITLE
Keep test files meant for scripted tests within a template

### DIFF
--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -288,6 +288,7 @@ object G8 {
         "template.properties",
         "project/template.properties",
         "test",
+        "!**/sbt-test/**/test",
         "!test/",
         "project/test",
         "!project/test/",


### PR DESCRIPTION
Fixes #394

To test this I ran `sbt new sbt/sbt-autoplugin.g8`. Like reported in #394 the `src/sbt-test/sbt-foo-bar/simple/test` was missing.

Now I did
1. To simulate this PR I added to the `.gitignore` file:
```
test
!**/sbt-test/**/test
!test/
```
1. created the file `src/sbt-test/sbt-foo-bar/simple/test` (the one that should not be ignored)
1. More testing by adding a `sbt-test` folder to the root dir containing various `test` files in various levels and a `test` file in the root folder and in a directory e.g `scr/main/`.

Now running:
```sh
$ git add .
$ git status 
On branch main
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   .gitignore
        new file:   sbt-test/foo/bar/test
        new file:   sbt-test/foo/test
        new file:   sbt-test/test
        new file:   src/sbt-test/sbt-foo-bar/simple/test
```

It's exactly what I wanted to see. All `test` files containted within a `sbt-test` folder get added, no matter which level they are in and no matter at which level the `sbt-test` folder is. All other `test` files get ignored.