### PR TITLE
Ignore [project/]test.script

### DIFF
--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -291,6 +291,8 @@ object G8 {
         "!test/",
         "project/test",
         "!project/test/",
+        "test.script",
+        "project/test.script",
         "giter8.test",
         "project/giter8.test",
         "g8.test",


### PR DESCRIPTION
In d6c008796146374ff7ababf0d5f987d6447e55ed the alias `test.script` was introduced but wasn't added to the ignored files.
IMHO it's exactly the same like the files `[project/]giter8.test`and `[project/]g8.test`