### PR TITLE
remove unnecessary scripted-plugin setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,19 +121,6 @@ lazy val plugin = (project in file("plugin"))
     scripted := scripted
       .dependsOn(lib / publishLocal)
       .evaluated,
-    libraryDependencies += {
-      val crossSbtVersion = (pluginCrossBuild / sbtVersion).value
-
-      val artifact =
-        partialVersion(crossSbtVersion) match {
-          case Some((1, _)) =>
-            "org.scala-sbt" %% "scripted-plugin"
-          case _ =>
-            throw new Exception(s"unexpected sbt version: $crossSbtVersion (supported: 1.X)")
-        }
-
-      artifact % crossSbtVersion
-    },
     Test / test := {
       scripted.toTask("").value
     }


### PR DESCRIPTION
`sbt.plugins.SbtPlugin` pulls `ScriptedPlugin` dependency.

https://github.com/sbt/sbt/blob/c5b11a41a923ba41d6f03661fd0877021eadbdd1/main/src/main/scala/sbt/plugins/SbtPlugin.scala#L15-L16

cross build for sbt 0.13 need different settings

https://github.com/foundweekends/giter8/commit/3b2bf6caeaafd87d679c305eb0817feccd5febf4#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91R119