### PR TITLE
avoid deprecated `scala.App`. add explicit main

### DIFF
--- a/launcher/src/main/scala/LauncherMain.scala
+++ b/launcher/src/main/scala/LauncherMain.scala
@@ -6,10 +6,12 @@ import java.util.Properties
 import java.lang.reflect.InvocationTargetException
 import java.nio.file.{Files, StandardCopyOption}
 
-object LauncherMain extends Runner with App {
-  java.util.logging.Logger.getLogger("").setLevel(java.util.logging.Level.SEVERE)
+object LauncherMain extends Runner {
+  def main(args: Array[String]): Unit = {
+    java.util.logging.Logger.getLogger("").setLevel(java.util.logging.Level.SEVERE)
 
-  System.exit(run(args, new LauncherProcessor))
+    System.exit(run(args, new LauncherProcessor))
+  }
 }
 
 class LauncherProcessor extends Processor {

--- a/library/src/test/resources/testcases/simple-sbt-project/output/example-sbt-project/src/main/scala/com/example/Main.scala
+++ b/library/src/test/resources/testcases/simple-sbt-project/output/example-sbt-project/src/main/scala/com/example/Main.scala
@@ -1,5 +1,7 @@
 package com.example
 
-object Main extends App {
-  println("Hello from project Example SBT project")
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("Hello from project Example SBT project")
+  }
 }

--- a/library/src/test/resources/testcases/simple-sbt-project/template/src/main/g8/src/main/scala/$package$/Main.scala
+++ b/library/src/test/resources/testcases/simple-sbt-project/template/src/main/g8/src/main/scala/$package$/Main.scala
@@ -1,5 +1,7 @@
 package $package$
 
-object Main extends App {
-  println("Hello from project $name$")
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("Hello from project $name$")
+  }
 }

--- a/plugin/src/sbt-test/giter8/root-layout/Main.scala
+++ b/plugin/src/sbt-test/giter8/root-layout/Main.scala
@@ -17,6 +17,8 @@
 
 package $package$
 
-object Main extends App {
-  println("hello")
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("hello")
+  }
 }

--- a/plugin/src/sbt-test/giter8/simple/src/main/g8/src/main/scala/Main.scala
+++ b/plugin/src/sbt-test/giter8/simple/src/main/g8/src/main/scala/Main.scala
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
-object Main extends App {
-  println("hello")
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("hello")
+  }
 }

--- a/plugin/src/sbt-test/giter8/without-name/src/main/g8/src/main/scala/$package$/Main.scala
+++ b/plugin/src/sbt-test/giter8/without-name/src/main/g8/src/main/scala/$package$/Main.scala
@@ -1,5 +1,7 @@
 package $package$
 
-object Main extends App {
-  println("Hello from project without name")
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("Hello from project without name")
+  }
 }


### PR DESCRIPTION
https://github.com/scala/scala/blob/01f25e8c7f27dd2e3040d7a5b2ba4a0a2c816b68/src/library/scala/App.scala#L35-L60

> If programs need to cross-build between Scala 2 and Scala 3, it is recommended to use an explicit `main` method: