### PR TITLE
fix: Fix "SLF4J: Failed to load ..." issue by adding slf4j-simple

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,3 +1,5 @@
+pullRequests.frequency = "14 days"
+
 updates.limit = 3
 
 updates.pin = [
@@ -5,7 +7,8 @@ updates.pin = [
     // jgit 6.x require JDK 11
     groupId = "org.eclipse.jgit"
     version = "5."
-  }
+  },
+  { groupId = "org.slf4j", artifactId = "slf4j-simple", version = "1." }
 ]
 
 updates.ignore = [

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,10 @@ lazy val app = (project in file("app"))
     csRun / sourceDirectory := {
       (baseDirectory).value.getParentFile / "src" / "main" / "conscript"
     },
-    libraryDependencies += launcherIntf
+    libraryDependencies ++= List(
+      launcherIntf,
+      slf4jsimple
+    )
   )
 
 lazy val crossSbt = Seq(
@@ -157,14 +160,14 @@ lazy val lib = (project in file("library"))
     libraryDependencies ++= Seq(
       stringTemplate,
       jgit,
+      slf4jsimple,
       commonsIo,
       plexusArchiver,
       scalaXml,
       parserCombinator(scalaVersion.value),
       scalacheck % Test,
       sbtIo % Test,
-      scalamock % Test,
-      "org.slf4j" % "slf4j-simple" % "1.7.36" % Test
+      scalamock % Test
     ),
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaCheck, "-minSuccessfulTests", "1000", "-workers", "10")
   )
@@ -179,6 +182,7 @@ lazy val launcher = (project in file("launcher"))
     crossScalaVersions := List(scala212, scala213, scala3),
     libraryDependencies ++= Seq(
       coursier,
+      slf4jsimple,
       verify % Test,
       sbtIo % Test
     ),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,6 +39,7 @@ object Dependencies {
       case _            => "2.2.0"
     }
   }
+  val slf4jsimple  = "org.slf4j" % "slf4j-simple" % "1.7.36"
   val logback      = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val coursier     = "io.get-coursier" %% "coursier" % "2.1.13"
   val launcherIntf = "org.scala-sbt" % "launcher-interface" % "1.4.4"


### PR DESCRIPTION
Fixes https://github.com/foundweekends/giter8/issues/931

## Problem

```bash
sbt new raquo/scalajs.g8
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

This is due to JGit adding slf4j-api but removed the binding at some point.

## Solution

This adds slf4j-simple 1.7 to the depdency.