### PR TITLE
set `User-Agent` header

### DIFF
--- a/library/src/main/scala/giter8/MavenHelper.scala
+++ b/library/src/main/scala/giter8/MavenHelper.scala
@@ -62,6 +62,7 @@ trait MavenHelper {
   def withHttp[A](url: URL)(f: HttpURLConnection => A): A = {
     val conn = url.openConnection()
     try {
+      conn.setRequestProperty("User-Agent", "giter8")
       conn match {
         case httpConn: HttpURLConnection => f(httpConn)
       }


### PR DESCRIPTION
avoid 403 error

```
Error: [info] [error] java.lang.RuntimeException: Unexpected response status 403 fetching metadata from https://repo1.maven.org/maven2/net/databinder/dispatch/dispatch-core_2.11/maven-metadata.xml
Error: [info] [error] 	at scala.sys.package$.error(package.scala:30)
Error: [info] [error] 	at giter8.Giter8Plugin$.$anonfun$baseGiter8Settings$9(Giter8Plugin.scala:100)
Error: [info] [error] 	at scala.util.Either.fold(Either.scala:192)
Error: [info] [error] 	at giter8.Giter8Plugin$.$anonfun$baseGiter8Settings$8(Giter8Plugin.scala:103)
Error: [info] [error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
Error: [info] [error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
Error: [info] [error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:67)
Error: [info] [error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:281)
Error: [info] [error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
Error: [info] [error] 	at sbt.Execute.work(Execute.scala:290)
Error: [info] [error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:281)
Error: [info] [error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
Error: [info] [error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
Error: [info] [error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
```