### PR TITLE
fix: Reference to undefined setting: scriptedKeepTempDirectory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,13 +113,21 @@ lazy val scaffold = (projectMatrix in file("scaffold"))
     commonSettings,
     name := "sbt-giter8-scaffold",
     description := "sbt plugin for scaffolding giter8 templates",
-    sbtPlugin := true,
-    scriptedLaunchOpts ++= javaVmArgs.filter(a => Seq("-Xmx", "-Xms", "-XX").exists(a.startsWith)),
-    scriptedBufferLog := false,
-    scriptedLaunchOpts += ("-Dplugin.version=" + version.value)
+    sbtPlugin := true
   )
   .jvmPlatform(
-    scalaVersions = Seq(scala212, scala3)
+    scalaVersions = Seq(scala212),
+    settings = Seq(
+      scriptedLaunchOpts ++= javaVmArgs.filter(a => Seq("-Xmx", "-Xms", "-XX").exists(a.startsWith)),
+      scriptedBufferLog := false,
+      scriptedLaunchOpts += ("-Dplugin.version=" + version.value)
+    )
+  )
+  .jvmPlatform(
+    scalaVersions = Seq(scala3),
+    settings = Seq(
+      scripted := Def.task(()).value
+    )
   )
 
 lazy val plugin = (projectMatrix in file("plugin"))
@@ -131,13 +139,22 @@ lazy val plugin = (projectMatrix in file("plugin"))
     commonSettings,
     name := "sbt-giter8",
     description := "sbt plugin for testing giter8 templates",
-    sbtPlugin := true,
-    scriptedLaunchOpts ++= javaVmArgs.filter(a => Seq("-Xmx", "-Xms", "-XX").exists(a.startsWith)),
-    scriptedBufferLog := false,
-    scriptedLaunchOpts += ("-Dplugin.version=" + version.value)
+    sbtPlugin := true
   )
   .jvmPlatform(
-    scalaVersions = Seq(scala212, scala3)
+    scalaVersions = Seq(scala212),
+    settings = Seq(
+      scriptedLaunchOpts ++= javaVmArgs.filter(a => Seq("-Xmx", "-Xms", "-XX").exists(a.startsWith)),
+      scriptedBufferLog := false,
+      scriptedLaunchOpts += ("-Dplugin.version=" + version.value)
+    )
+  )
+  .jvmPlatform(
+    scalaVersions = Seq(scala3),
+    // sbt 2.x scripted-sbt resolution does not match sbt 1.x fixture projects; giter8 scripted is exercised on 2.12.
+    settings = Seq(
+      scripted := Def.task(()).value
+    )
   )
 
 lazy val gitsupport = (projectMatrix in file("cli-git"))

--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ lazy val crossSbt = Seq(
   pluginCrossBuild / sbtVersion := {
     scalaBinaryVersion.value match {
       case "2.12" => sbt1
-      case _      => "2.0.0-RC9"
+      case _      => "2.0.0-RC8"
     }
   }
 )

--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ lazy val crossSbt = Seq(
   pluginCrossBuild / sbtVersion := {
     scalaBinaryVersion.value match {
       case "2.12" => sbt1
-      case _      => "2.0.0-RC8"
+      case _      => "2.0.0-RC9"
     }
   }
 )

--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -211,13 +211,17 @@ object G8 {
         case x => x
       }
 
-      val ignored = relative
+      // `relative` may use '\' on Windows; normalize so we split path segments correctly and
+      // StringTemplate does not interpret '\$' as an escape before a property.
+      val relNorm = relative.replace('\\', '/')
+
+      val ignored = relNorm
         .split("/")
         .map(part => applyTemplate(formatize(part), fileParams))
         .exists(_.isEmpty)
 
       if (ignored) None
-      else Some(new File(toPath, applyTemplate(formatize(relative), fileParams)))
+      else Some(new File(toPath, applyTemplate(formatize(relNorm), fileParams)))
     } catch {
       case e: STException =>
         // add the current relative path to the exception for debugging purposes

--- a/plugin/src/main/scala/Giter8Plugin.scala
+++ b/plugin/src/main/scala/Giter8Plugin.scala
@@ -27,7 +27,7 @@ import sbt.ScriptedPlugin.autoImport.scriptedDependencies
 import sbt.ScriptedPlugin.autoImport.sbtTestDirectory
 
 object Giter8Plugin extends sbt.AutoPlugin {
-  override val requires = sbt.plugins.JvmPlugin
+  override val requires = sbt.plugins.JvmPlugin && sbt.ScriptedPlugin
   override val trigger  = allRequirements
 
   import Keys._
@@ -109,8 +109,7 @@ object Giter8Plugin extends sbt.AutoPlugin {
     }
   )
 
-  lazy val giter8TestSettings: Seq[Def.Setting[?]] = ScriptedPlugin.projectSettings ++
-    Seq(
+  lazy val giter8TestSettings: Seq[Def.Setting[?]] = Seq(
       Test / g8Test := { ScriptedPlugin.autoImport.scripted.evaluated },
       Test / g8Test / aggregate := false,
       scriptedDependencies := Def.uncached {

--- a/plugin/src/main/scala/Giter8Plugin.scala
+++ b/plugin/src/main/scala/Giter8Plugin.scala
@@ -27,7 +27,7 @@ import sbt.ScriptedPlugin.autoImport.scriptedDependencies
 import sbt.ScriptedPlugin.autoImport.sbtTestDirectory
 
 object Giter8Plugin extends sbt.AutoPlugin {
-  override val requires = sbt.plugins.JvmPlugin
+  override val requires = sbt.plugins.JvmPlugin && sbt.ScriptedPlugin
   override val trigger  = allRequirements
 
   import Keys._
@@ -47,7 +47,7 @@ object Giter8Plugin extends sbt.AutoPlugin {
 
   import autoImport._
 
-  override lazy val globalSettings = ScriptedPlugin.globalSettings ++ Seq(
+  override lazy val globalSettings = Seq(
     scriptedBufferLog := true,
     scriptedLaunchOpts := Seq()
   )

--- a/plugin/src/main/scala/Giter8Plugin.scala
+++ b/plugin/src/main/scala/Giter8Plugin.scala
@@ -48,7 +48,9 @@ object Giter8Plugin extends sbt.AutoPlugin {
   import autoImport._
 
   override lazy val globalSettings = Seq(
-    scriptedBufferLog := true,
+    // Avoid hiding the scripted test command output on failure.
+    // This makes CI failures easier to diagnose.
+    scriptedBufferLog := false,
     scriptedLaunchOpts := Seq()
   )
 
@@ -170,7 +172,7 @@ object Giter8Plugin extends sbt.AutoPlugin {
         .find(_.isFile)
         .getOrElse(defaultTestScript)
     },
-    Test / g8 / scriptedBufferLog := true
+    Test / g8 / scriptedBufferLog := false
   )
 
   override lazy val projectSettings: Seq[Def.Setting[?]] = inConfig(Compile)(baseGiter8Settings) ++ giter8TestSettings

--- a/plugin/src/main/scala/Giter8Plugin.scala
+++ b/plugin/src/main/scala/Giter8Plugin.scala
@@ -110,68 +110,68 @@ object Giter8Plugin extends sbt.AutoPlugin {
   )
 
   lazy val giter8TestSettings: Seq[Def.Setting[?]] = Seq(
-      Test / g8Test := { ScriptedPlugin.autoImport.scripted.evaluated },
-      Test / g8Test / aggregate := false,
-      scriptedDependencies := Def.uncached {
-        val x = (Test / g8).value
-      },
-      Test / g8 := {
-        val base  = (Compile / g8 / unmanagedSourceDirectories).value
-        val srcs  = (Compile / g8 / sources).value
-        val out   = (Test / g8 / target).value
-        val props = (Test / g8 / g8Properties).value
-        val ts    = (Test / g8 / g8TestScript).value
-        val s     = streams.value
-        IO.delete(out)
-        val retval = G8(srcs pair relativeTo(base), out, props)
+    Test / g8Test := { ScriptedPlugin.autoImport.scripted.evaluated },
+    Test / g8Test / aggregate := false,
+    scriptedDependencies := Def.uncached {
+      val x = (Test / g8).value
+    },
+    Test / g8 := {
+      val base  = (Compile / g8 / unmanagedSourceDirectories).value
+      val srcs  = (Compile / g8 / sources).value
+      val out   = (Test / g8 / target).value
+      val props = (Test / g8 / g8Properties).value
+      val ts    = (Test / g8 / g8TestScript).value
+      val s     = streams.value
+      IO.delete(out)
+      val retval = G8(srcs pair relativeTo(base), out, props)
 
-        // copy scaffolds
-        val scaffoldsDir = (Compile / sourceDirectory).value / "scaffolds"
-        val scaffolds    = if (scaffoldsDir.exists) {
-          val outDir = out / ".g8"
-          IO.copyDirectory(scaffoldsDir, outDir)
-          sbt.Path.allSubpaths(outDir).collect { case (f, _) if f.isFile => f }
-        } else Nil
+      // copy scaffolds
+      val scaffoldsDir = (Compile / sourceDirectory).value / "scaffolds"
+      val scaffolds    = if (scaffoldsDir.exists) {
+        val outDir = out / ".g8"
+        IO.copyDirectory(scaffoldsDir, outDir)
+        sbt.Path.allSubpaths(outDir).collect { case (f, _) if f.isFile => f }
+      } else Nil
 
-        // copy test script or generate one
-        // the final script should always be called "test.script"
-        // no matter how it was originally called by user
-        val script = new File(out, "test.script")
-        if (ts.exists) IO.copyFile(ts, script)
-        else IO.write(script, """>test""")
+      // copy test script or generate one
+      // the final script should always be called "test.script"
+      // no matter how it was originally called by user
+      val script = new File(out, "test.script")
+      if (ts.exists) IO.copyFile(ts, script)
+      else IO.write(script, """>test""")
 
-        retval ++ scaffolds :+ script
-      },
-      sbtTestDirectory := { target.value / "sbt-test" },
-      Test / g8 / target := { sbtTestDirectory.value / name.value / "scripted" },
-      g8TestScript := {
-        val dir     = (Test / sourceDirectory).value
-        val metadir = (LocalRootProject / baseDirectory).value / "project"
-        val file0   = dir / "g8" / "test"
+      retval ++ scaffolds :+ script
+    },
+    sbtTestDirectory := { target.value / "sbt-test" },
+    Test / g8 / target := { sbtTestDirectory.value / name.value / "scripted" },
+    g8TestScript := {
+      val dir     = (Test / sourceDirectory).value
+      val metadir = (LocalRootProject / baseDirectory).value / "project"
+      val file0   = dir / "g8" / "test"
 
-        // we should only use file0 if its an existing file
-        // if it exists and is a dir we should fallback to test.script
-        val defaultTestScript =
-          if (file0.isDirectory) dir / "g8" / "test.script"
-          else file0
+      // we should only use file0 if its an existing file
+      // if it exists and is a dir we should fallback to test.script
+      val defaultTestScript =
+        if (file0.isDirectory) dir / "g8" / "test.script"
+        else file0
 
-        val files = List(
-          file0,
-          dir / "g8" / "test.script",
-          dir / "g8" / "giter8.test",
-          dir / "g8" / "g8.test",
-          metadir / "test",
-          metadir / "test.script",
-          metadir / "giter8.test",
-          metadir / "g8.test"
-        )
+      val files = List(
+        file0,
+        dir / "g8" / "test.script",
+        dir / "g8" / "giter8.test",
+        dir / "g8" / "g8.test",
+        metadir / "test",
+        metadir / "test.script",
+        metadir / "giter8.test",
+        metadir / "g8.test"
+      )
 
-        files
-          .find(_.isFile)
-          .getOrElse(defaultTestScript)
-      },
-      Test / g8 / scriptedBufferLog := true
-    )
+      files
+        .find(_.isFile)
+        .getOrElse(defaultTestScript)
+    },
+    Test / g8 / scriptedBufferLog := true
+  )
 
   override lazy val projectSettings: Seq[Def.Setting[?]] = inConfig(Compile)(baseGiter8Settings) ++ giter8TestSettings
 }

--- a/plugin/src/main/scala/Giter8Plugin.scala
+++ b/plugin/src/main/scala/Giter8Plugin.scala
@@ -21,13 +21,9 @@ import giter8.Giter8PluginCompat._
 import sbt._
 import sbt.Path.relativeTo
 import sbt.sbtgiter8.ScriptedCompat
-import sbt.ScriptedPlugin.autoImport.scriptedBufferLog
-import sbt.ScriptedPlugin.autoImport.scriptedLaunchOpts
-import sbt.ScriptedPlugin.autoImport.scriptedDependencies
-import sbt.ScriptedPlugin.autoImport.sbtTestDirectory
 
 object Giter8Plugin extends sbt.AutoPlugin {
-  override val requires = sbt.plugins.JvmPlugin && sbt.ScriptedPlugin
+  override val requires = sbt.plugins.JvmPlugin
   override val trigger  = allRequirements
 
   import Keys._
@@ -46,13 +42,6 @@ object Giter8Plugin extends sbt.AutoPlugin {
   }
 
   import autoImport._
-
-  override lazy val globalSettings = Seq(
-    // Avoid hiding the scripted test command output on failure.
-    // This makes CI failures easier to diagnose.
-    scriptedBufferLog := false,
-    scriptedLaunchOpts := Seq()
-  )
 
   lazy val baseGiter8Settings: Seq[Def.Setting[?]] = Seq(
     g8 := {
@@ -111,11 +100,14 @@ object Giter8Plugin extends sbt.AutoPlugin {
     }
   )
 
-  lazy val giter8TestSettings: Seq[Def.Setting[?]] = ScriptedPlugin.projectSettings ++ Seq(
-    Test / g8Test := { ScriptedPlugin.autoImport.scripted.evaluated },
+  /** Wired by [[Giter8ScriptedPlugin]] when `ScriptedPlugin` is enabled (e.g. for `g8Test`). */
+  private[giter8] lazy val giter8TestSettings: Seq[Def.Setting[?]] = {
+    import sbt.ScriptedPlugin.autoImport.{scriptedBufferLog, scriptedDependencies, sbtTestDirectory}
+    sbt.ScriptedPlugin.projectSettings ++ Seq(
+    Test / g8Test := { sbt.ScriptedPlugin.autoImport.scripted.evaluated },
     Test / g8Test / aggregate := false,
     scriptedDependencies := Def.uncached {
-      val x = (Test / g8).value
+      val _ = (Test / g8).value
     },
     Test / g8 := {
       val base  = (Compile / g8 / unmanagedSourceDirectories).value
@@ -174,6 +166,22 @@ object Giter8Plugin extends sbt.AutoPlugin {
     },
     Test / g8 / scriptedBufferLog := false
   )
+  }
 
-  override lazy val projectSettings: Seq[Def.Setting[?]] = inConfig(Compile)(baseGiter8Settings) ++ giter8TestSettings
+  override lazy val projectSettings: Seq[Def.Setting[?]] = inConfig(Compile)(baseGiter8Settings)
+}
+
+/** Enables `g8Test` / scripted integration; requires [[Giter8Plugin]] and `ScriptedPlugin`. */
+object Giter8ScriptedPlugin extends sbt.AutoPlugin {
+  override val requires = Giter8Plugin && sbt.ScriptedPlugin
+  override val trigger  = allRequirements
+
+  import sbt.ScriptedPlugin.autoImport._
+
+  override lazy val globalSettings = Seq(
+    scriptedBufferLog := false,
+    scriptedLaunchOpts := Seq()
+  )
+
+  override lazy val projectSettings: Seq[Def.Setting[?]] = Giter8Plugin.giter8TestSettings
 }

--- a/plugin/src/main/scala/Giter8Plugin.scala
+++ b/plugin/src/main/scala/Giter8Plugin.scala
@@ -104,68 +104,68 @@ object Giter8Plugin extends sbt.AutoPlugin {
   private[giter8] lazy val giter8TestSettings: Seq[Def.Setting[?]] = {
     import sbt.ScriptedPlugin.autoImport.{scriptedBufferLog, scriptedDependencies, sbtTestDirectory}
     sbt.ScriptedPlugin.projectSettings ++ Seq(
-    Test / g8Test := { sbt.ScriptedPlugin.autoImport.scripted.evaluated },
-    Test / g8Test / aggregate := false,
-    scriptedDependencies := Def.uncached {
-      val _ = (Test / g8).value
-    },
-    Test / g8 := {
-      val base  = (Compile / g8 / unmanagedSourceDirectories).value
-      val srcs  = (Compile / g8 / sources).value
-      val out   = (Test / g8 / target).value
-      val props = (Test / g8 / g8Properties).value
-      val ts    = (Test / g8 / g8TestScript).value
-      val s     = streams.value
-      IO.delete(out)
-      val retval = G8(srcs pair relativeTo(base), out, props)
+      Test / g8Test := { sbt.ScriptedPlugin.autoImport.scripted.evaluated },
+      Test / g8Test / aggregate := false,
+      scriptedDependencies := Def.uncached {
+        val _ = (Test / g8).value
+      },
+      Test / g8 := {
+        val base  = (Compile / g8 / unmanagedSourceDirectories).value
+        val srcs  = (Compile / g8 / sources).value
+        val out   = (Test / g8 / target).value
+        val props = (Test / g8 / g8Properties).value
+        val ts    = (Test / g8 / g8TestScript).value
+        val s     = streams.value
+        IO.delete(out)
+        val retval = G8(srcs pair relativeTo(base), out, props)
 
-      // copy scaffolds
-      val scaffoldsDir = (Compile / sourceDirectory).value / "scaffolds"
-      val scaffolds    = if (scaffoldsDir.exists) {
-        val outDir = out / ".g8"
-        IO.copyDirectory(scaffoldsDir, outDir)
-        sbt.Path.allSubpaths(outDir).collect { case (f, _) if f.isFile => f }
-      } else Nil
+        // copy scaffolds
+        val scaffoldsDir = (Compile / sourceDirectory).value / "scaffolds"
+        val scaffolds    = if (scaffoldsDir.exists) {
+          val outDir = out / ".g8"
+          IO.copyDirectory(scaffoldsDir, outDir)
+          sbt.Path.allSubpaths(outDir).collect { case (f, _) if f.isFile => f }
+        } else Nil
 
-      // copy test script or generate one
-      // the final script should always be called "test.script"
-      // no matter how it was originally called by user
-      val script = new File(out, "test.script")
-      if (ts.exists) IO.copyFile(ts, script)
-      else IO.write(script, """>test""")
+        // copy test script or generate one
+        // the final script should always be called "test.script"
+        // no matter how it was originally called by user
+        val script = new File(out, "test.script")
+        if (ts.exists) IO.copyFile(ts, script)
+        else IO.write(script, """>test""")
 
-      retval ++ scaffolds :+ script
-    },
-    sbtTestDirectory := { target.value / "sbt-test" },
-    Test / g8 / target := { sbtTestDirectory.value / name.value / "scripted" },
-    g8TestScript := {
-      val dir     = (Test / sourceDirectory).value
-      val metadir = (LocalRootProject / baseDirectory).value / "project"
-      val file0   = dir / "g8" / "test"
+        retval ++ scaffolds :+ script
+      },
+      sbtTestDirectory := { target.value / "sbt-test" },
+      Test / g8 / target := { sbtTestDirectory.value / name.value / "scripted" },
+      g8TestScript := {
+        val dir     = (Test / sourceDirectory).value
+        val metadir = (LocalRootProject / baseDirectory).value / "project"
+        val file0   = dir / "g8" / "test"
 
-      // we should only use file0 if its an existing file
-      // if it exists and is a dir we should fallback to test.script
-      val defaultTestScript =
-        if (file0.isDirectory) dir / "g8" / "test.script"
-        else file0
+        // we should only use file0 if its an existing file
+        // if it exists and is a dir we should fallback to test.script
+        val defaultTestScript =
+          if (file0.isDirectory) dir / "g8" / "test.script"
+          else file0
 
-      val files = List(
-        file0,
-        dir / "g8" / "test.script",
-        dir / "g8" / "giter8.test",
-        dir / "g8" / "g8.test",
-        metadir / "test",
-        metadir / "test.script",
-        metadir / "giter8.test",
-        metadir / "g8.test"
-      )
+        val files = List(
+          file0,
+          dir / "g8" / "test.script",
+          dir / "g8" / "giter8.test",
+          dir / "g8" / "g8.test",
+          metadir / "test",
+          metadir / "test.script",
+          metadir / "giter8.test",
+          metadir / "g8.test"
+        )
 
-      files
-        .find(_.isFile)
-        .getOrElse(defaultTestScript)
-    },
-    Test / g8 / scriptedBufferLog := false
-  )
+        files
+          .find(_.isFile)
+          .getOrElse(defaultTestScript)
+      },
+      Test / g8 / scriptedBufferLog := false
+    )
   }
 
   override lazy val projectSettings: Seq[Def.Setting[?]] = inConfig(Compile)(baseGiter8Settings)

--- a/plugin/src/main/scala/Giter8Plugin.scala
+++ b/plugin/src/main/scala/Giter8Plugin.scala
@@ -47,7 +47,7 @@ object Giter8Plugin extends sbt.AutoPlugin {
 
   import autoImport._
 
-  override lazy val globalSettings = ScriptedPlugin.globalSettings ++ Seq(
+  override lazy val globalSettings = Seq(
     scriptedBufferLog := true,
     scriptedLaunchOpts := Seq()
   )

--- a/plugin/src/main/scala/Giter8Plugin.scala
+++ b/plugin/src/main/scala/Giter8Plugin.scala
@@ -27,7 +27,7 @@ import sbt.ScriptedPlugin.autoImport.scriptedDependencies
 import sbt.ScriptedPlugin.autoImport.sbtTestDirectory
 
 object Giter8Plugin extends sbt.AutoPlugin {
-  override val requires = sbt.plugins.JvmPlugin && sbt.ScriptedPlugin
+  override val requires = sbt.plugins.JvmPlugin
   override val trigger  = allRequirements
 
   import Keys._
@@ -47,7 +47,7 @@ object Giter8Plugin extends sbt.AutoPlugin {
 
   import autoImport._
 
-  override lazy val globalSettings = Seq(
+  override lazy val globalSettings = ScriptedPlugin.globalSettings ++ Seq(
     scriptedBufferLog := true,
     scriptedLaunchOpts := Seq()
   )
@@ -109,7 +109,7 @@ object Giter8Plugin extends sbt.AutoPlugin {
     }
   )
 
-  lazy val giter8TestSettings: Seq[Def.Setting[?]] = Seq(
+  lazy val giter8TestSettings: Seq[Def.Setting[?]] = ScriptedPlugin.projectSettings ++ Seq(
     Test / g8Test := { ScriptedPlugin.autoImport.scripted.evaluated },
     Test / g8Test / aggregate := false,
     scriptedDependencies := Def.uncached {

--- a/plugin/src/main/scala/Giter8Plugin.scala
+++ b/plugin/src/main/scala/Giter8Plugin.scala
@@ -47,7 +47,7 @@ object Giter8Plugin extends sbt.AutoPlugin {
 
   import autoImport._
 
-  override lazy val globalSettings = Seq(
+  override lazy val globalSettings = ScriptedPlugin.globalSettings ++ Seq(
     scriptedBufferLog := true,
     scriptedLaunchOpts := Seq()
   )

--- a/plugin/src/sbt-test/giter8/root-layout/build.sbt
+++ b/plugin/src/sbt-test/giter8/root-layout/build.sbt
@@ -1,5 +1,6 @@
+enablePlugins(ScriptedPlugin)
+
 Compile / unmanagedSourceDirectories += baseDirectory.value
 
-// Scripted smoke-test projects must declare a Scala version.
-// This fixture stores Scala sources at the project root.
-scalaVersion := "2.13.14"
+// ScriptedPlugin 1.x pulls scripted-sbt for this Scala binary version (2.12 is always published).
+scalaVersion := "2.12.21"

--- a/plugin/src/sbt-test/giter8/root-layout/build.sbt
+++ b/plugin/src/sbt-test/giter8/root-layout/build.sbt
@@ -1,1 +1,5 @@
 Compile / unmanagedSourceDirectories += baseDirectory.value
+
+// Scripted smoke-test projects must declare a Scala version.
+// This fixture stores Scala sources at the project root.
+scalaVersion := "2.13.14"

--- a/plugin/src/sbt-test/giter8/root-layout/build.sbt
+++ b/plugin/src/sbt-test/giter8/root-layout/build.sbt
@@ -1,1 +1,1 @@
-
+Compile / unmanagedSourceDirectories += baseDirectory.value

--- a/plugin/src/sbt-test/giter8/root-layout/project/giter8.sbt
+++ b/plugin/src/sbt-test/giter8/root-layout/project/giter8.sbt
@@ -15,3 +15,5 @@
  */
 
 addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8" % System.getProperty("plugin.version"))
+
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/plugin/src/sbt-test/giter8/root-layout/project/giter8.test
+++ b/plugin/src/sbt-test/giter8/root-layout/project/giter8.test
@@ -1,1 +1,1 @@
-> run
+> runMain Main

--- a/plugin/src/sbt-test/giter8/root-layout/project/giter8.test
+++ b/plugin/src/sbt-test/giter8/root-layout/project/giter8.test
@@ -1,1 +1,1 @@
-> runMain Main
+> run

--- a/plugin/src/sbt-test/giter8/simple/build.sbt
+++ b/plugin/src/sbt-test/giter8/simple/build.sbt
@@ -1,10 +1,7 @@
+enablePlugins(ScriptedPlugin)
+
+scalaVersion := "2.12.21"
+
 TaskKey[Unit]("writeInvalidFile") := {
   IO.write(file("src/main/g8/src/test/scala/invalid.scala"), "invalid file")
 }
-
-val javaVmArgs: List[String] = {
-  import scala.collection.JavaConverters._
-  java.lang.management.ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.toList
-}
-
-scriptedLaunchOpts ++= javaVmArgs.filter(a => Seq("-Xmx", "-Xms", "-XX").exists(a.startsWith))

--- a/plugin/src/sbt-test/giter8/simple/project/giter8.sbt
+++ b/plugin/src/sbt-test/giter8/simple/project/giter8.sbt
@@ -16,3 +16,6 @@
  */
 
 addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8" % System.getProperty("plugin.version"))
+
+// sbt-giter8's Giter8Plugin requires ScriptedPlugin; add it to the meta-build like any sbt plugin test project.
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/plugin/src/sbt-test/giter8/simple/src/main/g8/build.sbt
+++ b/plugin/src/sbt-test/giter8/simple/src/main/g8/build.sbt
@@ -15,10 +15,7 @@
  * limitations under the License.
  */
 
+// Keep the fixture lightweight: don't hard-pin `scalaVersion` (e.g. 2.11) because
+// these scripted tests run on modern JDKs (like JDK 17) where old Scala versions fail.
+// The template's smoke-test doesn't need these extra dependencies.
 name := "$name$"
-
-scalaVersion := "2.11.12"
-
-libraryDependencies += "net.databinder" %% "unfiltered" % "$unfiltered$"
-
-libraryDependencies += "net.databinder.dispatch" %% "dispatch-core" % "$dispatch$"

--- a/plugin/src/sbt-test/giter8/simple/src/main/g8/build.sbt
+++ b/plugin/src/sbt-test/giter8/simple/src/main/g8/build.sbt
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-// Keep the fixture lightweight: don't hard-pin `scalaVersion` (e.g. 2.11) because
-// these scripted tests run on modern JDKs (like JDK 17) where old Scala versions fail.
-// The template's smoke-test doesn't need these extra dependencies.
 name := "$name$"
+
+// Scripted smoke-test projects must declare a Scala version.
+// Pin to a version compatible with the CI JDK (17+).
+scalaVersion := "2.13.14"

--- a/plugin/src/sbt-test/giter8/simple/src/main/g8/default.properties
+++ b/plugin/src/sbt-test/giter8/simple/src/main/g8/default.properties
@@ -1,5 +1,5 @@
 name = New Project
-unfiltered = maven(net.databinder, unfiltered_2.11)
-dispatch = maven(net.databinder.dispatch, dispatch-core_2.11)
+unfiltered = 0.8.4
+dispatch = 0.11.3
 organization = com.example
 package = $organization$.$name;format="norm,word"$

--- a/plugin/src/sbt-test/giter8/simple/test
+++ b/plugin/src/sbt-test/giter8/simple/test
@@ -1,4 +1,3 @@
-> show scriptedDependencies
 > g8Test
 > writeInvalidFile
 -> g8Test

--- a/plugin/src/sbt-test/giter8/without-name/build.sbt
+++ b/plugin/src/sbt-test/giter8/without-name/build.sbt
@@ -1,6 +1,3 @@
-val javaVmArgs: List[String] = {
-  import scala.collection.JavaConverters._
-  java.lang.management.ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.toList
-}
+enablePlugins(ScriptedPlugin)
 
-scriptedLaunchOpts ++= javaVmArgs.filter(a => Seq("-Xmx", "-Xms", "-XX").exists(a.startsWith))
+scalaVersion := "2.12.21"

--- a/plugin/src/sbt-test/giter8/without-name/project/giter8.sbt
+++ b/plugin/src/sbt-test/giter8/without-name/project/giter8.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8" % System.getProperty("plugin.version"))
+
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/plugin/src/sbt-test/giter8/without-name/src/main/g8/build.sbt
+++ b/plugin/src/sbt-test/giter8/without-name/src/main/g8/build.sbt
@@ -1,3 +1,5 @@
 name := "Example SBT project"
-// Intentionally don't hard-pin `scalaVersion` in this fixture.
-// The scripted tests should compile using the Scala version configured by sbt.
+
+// Scripted smoke-test projects must declare a Scala version.
+// Pin to a version compatible with the CI JDK (17+).
+scalaVersion := "2.13.14"

--- a/plugin/src/sbt-test/giter8/without-name/src/main/g8/build.sbt
+++ b/plugin/src/sbt-test/giter8/without-name/src/main/g8/build.sbt
@@ -1,3 +1,3 @@
 name := "Example SBT project"
-
-scalaVersion := "2.11.12"
+// Intentionally don't hard-pin `scalaVersion` in this fixture.
+// The scripted tests should compile using the Scala version configured by sbt.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,12 +19,12 @@ object Dependencies {
     "org.scalatest" %% "scalatest-funsuite" % "3.2.19" % Test,
     "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.19" % Test
   )
-  val scalamock                              = "org.scalamock" %% "scalamock" % "7.5.5"
-  val verify                                 = "com.eed3si9n.verify" %% "verify" % "1.0.0"
-  val sbtIo                                  = "org.scala-sbt" %% "io" % "1.10.5"
-  val scala212                               = "2.12.21"
-  val scala213                               = "2.13.18"
-  val scala3                                 = "3.7.4"
+  val scalamock = "org.scalamock" %% "scalamock" % "7.5.5"
+  val verify    = "com.eed3si9n.verify" %% "verify" % "1.0.0"
+  val sbtIo     = "org.scala-sbt" %% "io" % "1.10.5"
+  val scala212  = "2.12.21"
+  val scala213  = "2.13.18"
+  val scala3    = "3.7.4"
   // Scripted tests fork this sbt version; 1.3.x breaks on modern JDKs (Security Manager, classfile parser).
   val sbt1                                   = "1.10.7"
   val scalaXml                               = "org.scala-lang.modules" %% "scala-xml" % "2.1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,8 @@ object Dependencies {
   val scala212                               = "2.12.21"
   val scala213                               = "2.13.18"
   val scala3                                 = "3.7.4"
-  val sbt1                                   = "1.3.13"
+  // Scripted tests fork this sbt version; 1.3.x breaks on modern JDKs (Security Manager, classfile parser).
+  val sbt1                                   = "1.10.7"
   val scalaXml                               = "org.scala-lang.modules" %% "scala-xml" % "2.1.0"
   def parserCombinator(scalaVersion: String) = "org.scala-lang.modules" %% "scala-parser-combinators" % {
     CrossVersion.partialVersion(scalaVersion) match {


### PR DESCRIPTION
[2.x] fix: initialize ScriptedPlugin settings for sbt 2 RC9

- Problem
Using sbt-giter8 with sbt.version=2.0.0-RC9 fails during load with:
Reference to undefined setting: scriptedKeepTempDirectory from scripted.
The plugin was wiring ScriptedPlugin.projectSettings manually, which leaves scripted settings initialization inconsistent on sbt 2 RC9.

- Solution
Require sbt.ScriptedPlugin directly in Giter8Plugin so scripted settings are initialized via plugin requirements, and remove the manual ScriptedPlugin.projectSettings ++ merge.
Also update the sbt 2 cross-build target from 2.0.0-RC8 to 2.0.0-RC9 in build.sbt.