### PR TITLE
Use `cooldown.minimumAge` instead of `pullRequests.frequency`

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,4 +1,4 @@
-pullRequests.frequency = "14 days"
+updates.cooldown.minimumAge = "14 days"
 
 updates.limit = 3
 


### PR DESCRIPTION
- https://github.com/scala-steward-org/scala-steward/releases/tag/v0.38.0
- https://github.com/scala-steward-org/scala-steward/pull/3762