### PR TITLE
Fix warning. use temurin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     - uses: actions/setup-java@v5
       with:
         java-version: 17
-        distribution: adopt
+        distribution: temurin
     - uses: actions/checkout@v7
       with:
         fetch-depth: 10


### PR DESCRIPTION
> Notice: AdoptOpenJDK has moved to Eclipse Temurin https://github.com/actions/setup-java#supported-distributions please consider changing to the 'temurin' distribution type in your setup-java configuration.