### PR TITLE
Fix scriptedKeepTempDirectory undefined

### DIFF
--- a/plugin/src/main/scala/Giter8Plugin.scala
+++ b/plugin/src/main/scala/Giter8Plugin.scala
@@ -47,7 +47,7 @@ object Giter8Plugin extends sbt.AutoPlugin {
 
   import autoImport._
 
-  override lazy val globalSettings = Seq(
+  override lazy val globalSettings = ScriptedPlugin.globalSettings ++ Seq(
     scriptedBufferLog := true,
     scriptedLaunchOpts := Seq()
   )


### PR DESCRIPTION
sbt 2.0.0-rc9 introduced scriptedKeepTempDirectory, which was undefined due to the globalSettings assignment not pulling in the new variable from ScriptedPlugin.globalSettings.

Fixes #1049